### PR TITLE
Add custom_field_values support to create_purchase_order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -910,6 +910,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1419,6 +1420,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1656,6 +1658,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1953,6 +1956,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2422,6 +2426,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2612,6 +2617,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/tools/purchase-orders.ts
+++ b/src/tools/purchase-orders.ts
@@ -4,6 +4,11 @@ import type { Server } from "../tool-helpers.js";
 import { jsonResponse, textResponse, withErrorHandling } from "../tool-helpers.js";
 import type { PaginationMeta, PurchaseOrder } from "../types.js";
 
+const customFieldValueSchema = z.object({
+  custom_field_id: z.number().int().describe("Custom field ID"),
+  value: z.string().describe("Custom field value"),
+});
+
 const lineItemSchema = z.object({
   description: z.string().describe("Item description"),
   quantity: z.number().describe("Quantity"),
@@ -13,6 +18,7 @@ const lineItemSchema = z.object({
   item_number: z.string().optional().describe("Item number"),
   sequence_no: z.number().int().optional().describe("Sequence number"),
   tax_rate_id: z.number().int().optional().describe("Tax rate ID"),
+  custom_field_values: z.array(customFieldValueSchema).optional().describe("Custom field values for this line item (for fields where on_line_item is true)"),
 });
 
 export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient): void {
@@ -73,16 +79,25 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
         notes: z.string().optional().describe("PO notes"),
         line_items: z.array(lineItemSchema).min(1).describe("Line items (at least one required)"),
         approver_list: z.array(z.number().int()).optional().describe("Approver IDs"),
+        custom_field_values: z.array(customFieldValueSchema).optional().describe("PO-level custom field values (for fields where on_line_item is false). Use get_company to discover available custom fields."),
       },
     },
     withErrorHandling(async (args) => {
-      const { commit, line_items, approver_list, ...poData } = args;
+      const { commit, line_items, approver_list, custom_field_values, ...poData } = args;
+      const lineItemsWithCfv = line_items.map((item) => {
+        const { custom_field_values: itemCfv, ...itemData } = item;
+        return {
+          ...itemData,
+          ...(itemCfv ? { custom_field_values_attributes: itemCfv } : {}),
+        };
+      });
       const body: Record<string, unknown> = {
         commit,
         purchase_order: {
           ...poData,
-          purchase_order_items_attributes: line_items,
+          purchase_order_items_attributes: lineItemsWithCfv,
           ...(approver_list ? { approver_list } : {}),
+          ...(custom_field_values ? { custom_field_values_attributes: custom_field_values } : {}),
         },
       };
       const po = await apiClient.post<PurchaseOrder>(apiClient.buildPath("/purchase_orders"), body);

--- a/tests/e2e/purchase-orders.test.ts
+++ b/tests/e2e/purchase-orders.test.ts
@@ -65,6 +65,39 @@ describe("Purchase Orders E2E", () => {
     expect(po.status).toBe("Draft");
   });
 
+  it("should create a purchase order with custom field values", async () => {
+    const po = await apiClient.post<any>(apiClient.buildPath("/purchase_orders"), {
+      commit: "Send",
+      purchase_order: {
+        creator_id: 1,
+        currency_id: 1,
+        department_id: 1,
+        supplier_id: 1,
+        purchase_order_items_attributes: [
+          {
+            description: "Nails",
+            quantity: 1,
+            unit_price: 5,
+            budget_id: 1,
+            custom_field_values_attributes: [
+              { custom_field_id: 10, value: "2026-03-06" },
+            ],
+          },
+        ],
+        custom_field_values_attributes: [
+          { custom_field_id: 1, value: "James' Credit Card" },
+          { custom_field_id: 2, value: "None" },
+        ],
+      },
+    });
+    expect(po.id).toBe(2);
+    expect(po.status).toBe("Pending");
+    expect(po.custom_field_values_attributes).toEqual([
+      { custom_field_id: 1, value: "James' Credit Card" },
+      { custom_field_id: 2, value: "None" },
+    ]);
+  });
+
   it("should get pending request count", async () => {
     const result = await apiClient.get<any>(apiClient.buildPath("/purchase_orders/pending_request_count"));
     expect(result.total_pending_request).toBe(3);


### PR DESCRIPTION
## Summary

Adds support for setting custom field values when creating purchase orders via the MCP server.

## Changes

### PO-level custom fields
- New `custom_field_values` parameter on `create_purchase_order` for fields where `on_line_item` is `false` (e.g. Payment Method, Recurring)
- Mapped to `custom_field_values_attributes` in the API request body

### Line-item-level custom fields
- New `custom_field_values` parameter on each line item for fields where `on_line_item` is `true` (e.g. date, Delivery Address)
- Mapped to `custom_field_values_attributes` on each `purchase_order_items_attributes` entry

### Schema
```json
{
  "custom_field_id": 1028,
  "value": "James' Credit Card"
}
```

Use `get_company` to discover available custom fields for the active company, then pass required/optional values when creating a PO.

## Why
Previously, purchase orders with required custom fields (e.g. Payment Method) could not be submitted via `commit: 'Send'` — the API returned a 400 error. This change allows the MCP client to pass custom field values, enabling full PO submission without needing to complete fields manually in the web app.

## Tests
- Added E2E test for creating a PO with custom field values at both PO and line item level
- All 50 tests pass