### PR TITLE
Add MCP skills and align tools with Rails API

### DIFF
--- a/.claude/skills/pex-approval-flows/SKILL.md
+++ b/.claude/skills/pex-approval-flows/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: pex-approval-flows
+description: >
+  ProcurementExpress approval flow configuration. Use when creating, updating, publishing,
+  or managing approval flows and their steps, conditions, and runs. Approval flows automate
+  the routing of POs and invoices to the right approvers based on configurable conditions.
+  Routes to MCP tools: list_approval_flows, get_approval_flow, create_approval_flow,
+  update_approval_flow, delete_approval_flow, archive_approval_flow, publish_approval_flow,
+  unpublish_approval_flow, list_approval_flow_runs, get_approval_flow_entity,
+  list_approval_flow_versions, get_approval_flow_version_details, rerun_approval_flows.
+  Triggers on: approval flow, approval workflow, approval steps, approval conditions,
+  approval routing, publish flow, flow runs, flow version, flow history, rerun approval.
+---
+
+# ProcurementExpress Approval Flows
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+The company must have `approval_flow_enabled` in company settings.
+
+## Tools Reference
+
+### list_approval_flows
+List active approval flows with search and pagination.
+- **Params:**
+  - `search` (optional) — search by flow name
+  - `page` (optional, integer), `per_page` (optional, integer — 10, 20, 50, 100)
+  - `sort` (optional, e.g. "name", "created_at"), `direction` (optional, "asc"/"desc")
+- **Returns:** `{ approval_flows: ApprovalFlow[], meta: PaginationMeta }`
+
+### get_approval_flow
+Get flow details including steps, approvers, and conditions.
+- **Params:** `id` (required, integer)
+- **Returns:** `ApprovalFlow`
+
+### create_approval_flow
+Create a flow with steps, approvers, and conditions. See [references/conditions.md](references/conditions.md).
+- **Params:**
+  - `name` (required, string)
+  - `document_type` (required, integer) — `0` = purchase order, `1` = invoice
+  - `self_approval_allowed` (optional, boolean) — allow PO creator to self-approve
+  - `steps` (required, array) — approval steps executed in step_no order:
+    - `step_no` (required, integer) — execution order
+    - `all_should_approve` (required, boolean) — true=all approvers, false=any one
+    - `approver_user_ids` (required, integer array) — approver user IDs
+    - `conditions` (optional, array) — step-level conditions (see [references/conditions.md](references/conditions.md))
+  - `conditions` (optional, array) — flow-level conditions that determine which documents match
+- **Returns:** `ApprovalFlow`
+
+### update_approval_flow
+Update a flow. Include `id` on steps/conditions to update existing, omit for new, `_destroy: true` to remove.
+- **Params:** `id` (required) + any create params
+- **Returns:** `ApprovalFlow`
+
+### delete_approval_flow
+Permanently delete a flow.
+- **Params:** `id` (required, integer)
+
+### archive_approval_flow
+Soft-delete (can be restored).
+- **Params:** `id` (required, integer)
+
+### publish_approval_flow
+Make a flow active. New POs/invoices will use this flow.
+- **Params:** `id` (required, integer)
+
+### unpublish_approval_flow
+Deactivate a flow. Existing runs continue but new documents won't use it.
+- **Params:** `id` (required, integer)
+
+### list_approval_flow_runs
+List documents that went through this flow with status and date filters.
+- **Params:**
+  - `id` (required, integer) — flow ID
+  - `status` (optional) — `"in_progress"`, `"completed"`, `"rejected"`
+  - `keyword` (optional) — search keyword
+  - `date_range` (optional) — `"24h"`, `"7d"`, `"30d"`, `"60d"`, `"custom"`
+  - `date_from`, `date_to` (optional) — for custom range
+  - `page`, `per_page` (optional)
+- **Returns:** Paginated flow run results
+
+## ApprovalFlow Response Fields
+
+- `id`, `name`, `document_type` (0=PO, 1=invoice), `self_approval_allowed`
+- `company_id`, `version_no`, `archived`, `status`
+- Counts: `in_progress_count`, `completed_count`, `rejected_count`, `total_runs_count`
+- `approval_steps[]` — each has: id, step_no, all_should_approve, approval_step_approvers[]
+  - Each approver: id, user_id, user_name, user_email
+- `approval_conditions[]` — flow-level conditions
+- `created_at`, `updated_at`
+
+## Version & Entity Tools
+
+### get_approval_flow_entity
+Get details about a specific PO or invoice that went through a flow.
+- **Params:** `id` (required, integer — flow ID), `entity_id` (required, integer — PO or invoice ID)
+- **Returns:** Entity details with approval status
+
+### list_approval_flow_versions
+List all version history of an approval flow.
+- **Params:** `id` (required, integer — flow ID)
+- **Returns:** Version history array
+
+### get_approval_flow_version_details
+Get full details of a specific flow version.
+- **Params:** `id` (required, integer — flow ID), `version_id` (required, integer)
+- **Returns:** Version details with steps and conditions
+
+### rerun_approval_flows
+Batch rerun approval flows for multiple POs and/or invoices. Use when flow rules have changed.
+- **Params:**
+  - `order_ids` (optional, integer array) — PO IDs to rerun flows for
+  - `invoice_ids` (optional, integer array) — invoice IDs to rerun flows for
+- At least one of `order_ids` or `invoice_ids` should be provided
+
+## Flow-Level vs Step-Level Conditions
+
+- **Flow-level conditions** determine WHICH documents match this flow (e.g., "only POs from Engineering department")
+- **Step-level conditions** determine WHICH steps activate for a matching document (e.g., "step 2 only if amount > $10,000")
+
+Both use the same condition schema. See [references/conditions.md](references/conditions.md).

--- a/.claude/skills/pex-approval-flows/references/conditions.md
+++ b/.claude/skills/pex-approval-flows/references/conditions.md
@@ -1,0 +1,90 @@
+# Approval Flow Conditions
+
+## Condition Schema
+
+Each condition in the `conditions` array accepts:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | integer | For updates | Existing condition ID |
+| `property` | string | Yes | What to evaluate (see Properties below) |
+| `operator` | string | Yes | How to compare (see Operators below) |
+| `value` | string | Yes | Value to compare against |
+| `custom_field_id` | integer | Only for custom fields | Custom field ID |
+| `_destroy` | boolean | No | Set true to remove (updates only) |
+
+## Properties
+
+| Property | Description | Value Format |
+|----------|-------------|-------------|
+| `budget` | Budget ID | Single budget ID |
+| `department` | Department ID | Single department ID |
+| `supplier` | Supplier ID | Single supplier ID |
+| `requester` | Requester user ID | Single user ID |
+| `gross_amount` | Gross total amount | Numeric string |
+| `net_amount` | Net total amount | Numeric string |
+| `custom_field_<id>` | Custom field value | Depends on field type |
+
+## Operators
+
+| Operator | Use With |
+|----------|----------|
+| `equals` | All properties |
+| `not_equals` | All properties |
+| `greater_than` | Amount properties |
+| `less_than` | Amount properties |
+| `is_any_of` | ID properties (comma-separated IDs) |
+| `is_none_of` | ID properties (comma-separated IDs) |
+| `exists` | Custom field properties (check if value exists) |
+| `not_exists` | Custom field properties (check if value is empty) |
+| `contains` | Text/ID properties (comma-separated IDs or substring) |
+| `not_contains` | Text/ID properties (comma-separated IDs or substring) |
+
+Operators are passed as string values (e.g. `"equals"`, `"greater_than"`).
+
+## Examples
+
+**Flow matches POs from Engineering department (ID: 5):**
+```json
+{ "property": "department", "operator": "0", "value": "5" }
+```
+
+**Step activates when gross amount > $10,000:**
+```json
+{ "property": "gross_amount", "operator": "2", "value": "10000" }
+```
+
+**Flow matches POs from suppliers 1, 2, or 3:**
+```json
+{ "property": "supplier", "operator": "4", "value": "1,2,3" }
+```
+
+**Condition on custom field (ID: 42) equals "urgent":**
+```json
+{ "property": "custom_field_42", "operator": "0", "value": "urgent", "custom_field_id": 42 }
+```
+
+## Approval Step Schema
+
+Each step in the `steps` array:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | integer | For updates | Existing step ID |
+| `step_no` | integer | Yes | Execution order (1, 2, 3...) |
+| `all_should_approve` | boolean | Yes | true = all approvers must approve, false = any one suffices |
+| `approver_user_ids` | integer[] | Yes | User IDs of approvers for this step |
+| `conditions` | array | No | Step-level conditions (same schema as above) |
+| `_destroy` | boolean | No | Remove step (updates only) |
+
+## Workflow: Create a Multi-Step Approval Flow
+
+```
+1. list_employees (pex-companies) → get approver user IDs
+2. list_departments (pex-departments) → get department IDs for conditions
+3. create_approval_flow with:
+   - name, document_type (0=PO or 1=invoice)
+   - steps with step_no ordering and approver assignments
+   - conditions for flow-level matching
+4. publish_approval_flow → make it active
+```

--- a/.claude/skills/pex-auth/SKILL.md
+++ b/.claude/skills/pex-auth/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pex-auth
+description: >
+  ProcurementExpress authentication and user profile management. Use when authenticating
+  to the ProcurementExpress API (V1 static token or V3 OAuth2 login), validating or revoking
+  tokens, or managing the current user's profile. Routes to MCP tools: authenticate,
+  validate_token, revoke_token, get_current_user, update_current_user. Triggers on: login,
+  sign in, authenticate, token, session, user profile, my account, change password.
+---
+
+# ProcurementExpress Authentication
+
+## Prerequisites
+
+Authentication is ALWAYS required before any other ProcurementExpress MCP tool call.
+After authenticating, call `set_active_company` (pex-companies skill) to set the working company.
+
+## Authentication Modes
+
+The API version is set via `PROCUREMENTEXPRESS_API_VERSION` env var (`v1` or `v3`, default: `v1`).
+
+### V1 Authentication (Static Token)
+
+Call `authenticate` with:
+- `authentication_token` (optional if `PROCUREMENTEXPRESS_AUTH_TOKEN` env var is set)
+- `company_id` (optional if `PROCUREMENTEXPRESS_COMPANY_ID` env var is set)
+
+V1 tokens never expire. If both env vars are set, calling `authenticate` with no args works.
+
+### V3 Authentication (OAuth2)
+
+Call `authenticate` with:
+- `email` (required) — user's email address
+- `password` (required) — user's password
+
+Returns an access token with expiry time. V3 requires `PROCUREMENTEXPRESS_CLIENT_ID` and
+`PROCUREMENTEXPRESS_CLIENT_SECRET` env vars for the OAuth2 client credentials.
+
+**Note:** OTP/2FA is not currently supported by the MCP server. If the user's account has
+2FA enabled, V1 authentication with a static token should be used instead.
+
+## Tools Reference
+
+### authenticate
+Authenticate to the ProcurementExpress API.
+- **V1 params:** `authentication_token` (optional), `company_id` (optional)
+- **V3 params:** `email` (required), `password` (required)
+- **Returns:** Confirmation message (V1) or token with expiry info (V3)
+
+### validate_token
+Check if the current authentication token is valid.
+- **Params:** None
+- **Returns:** V1 returns `User` object, V3 returns `TokenInfo` (resource_owner_id, scopes, expires_in_seconds)
+
+### revoke_token
+End the current session.
+- **Params:** None
+- **V1:** Clears token locally (no server call)
+- **V3:** Revokes token on server via OAuth2 revocation endpoint, then clears locally
+
+### get_current_user
+Get the authenticated user's profile including company memberships and roles.
+- **Params:** None
+- **Returns:** `User` object with fields: id, email, name, phone_number, setup_incomplete, employer_id, approval_limit, companies[]
+- Each company in `companies[]` has: id, name, roles[], is_locked, in_trial, trial_expired, remaining_trial_days
+
+### update_current_user
+Update the authenticated user's profile.
+- **Params (all optional):** `email`, `name`, `first_name`, `last_name`, `phone_number`, `password`, `password_confirmation`
+- When changing password, both `password` and `password_confirmation` are required
+- **Returns:** Updated `User` object
+
+## Typical Workflow
+
+```
+1. authenticate → get session
+2. get_current_user → see available companies
+3. set_active_company (pex-companies) → pick a company
+4. Start using other ProcurementExpress tools
+```

--- a/.claude/skills/pex-budgets/SKILL.md
+++ b/.claude/skills/pex-budgets/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: pex-budgets
+description: >
+  ProcurementExpress budget management. Use when listing, viewing, creating, or updating
+  budgets (cost centers). Routes to MCP tools: list_budgets, get_budget, create_budget,
+  update_budget. Triggers on: budget, cost center, spending limit, budget allocation,
+  remaining budget, budget approvers.
+---
+
+# ProcurementExpress Budgets
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+
+## Tools Reference
+
+### list_budgets
+List budgets for the current company.
+- **Params:**
+  - `department_id` (optional, integer) — filter by department
+  - `archived` (optional, boolean, default: false)
+  - `show_mappings` (optional, boolean) — include third-party ID mappings
+- **Returns:** `Budget[]`
+
+### get_budget
+Get a specific budget with remaining amount and associations.
+- **Params:** `id` (required, integer)
+- **Returns:** `Budget`
+
+### create_budget
+Create a new budget.
+- **Params:**
+  - `name` (required, string)
+  - `amount` (required, number)
+  - `currency_id` (optional, integer) — defaults to company currency
+  - `creator_id` (optional, integer)
+  - `cost_code` (optional, string)
+  - `cost_type` (optional, string)
+  - `start_date` (optional, string) — must match company `date_format` setting
+  - `end_date` (optional, string) — must match company `date_format` setting
+  - `allow_anyone_to_approve_a_po` (optional, boolean)
+  - `chart_of_account_id` (optional, integer) — GL code
+  - `qbo_class` (optional, string) — QuickBooks class
+  - `approver_ids` (optional, integer array)
+  - `department_ids` (optional, integer array)
+  - `custom_field_values_attributes` (optional, array) — budget-level custom field values:
+    - `id` (optional, integer — for updates), `value` (required, string), `custom_field_id` (required, integer)
+    - Get available custom fields from `get_company_details` (pex-companies) → `custom_fields[]`
+- **Returns:** `Budget`
+
+### update_budget
+Update an existing budget. Same params as create except `id` is required, all others optional.
+- **Params:** `id` (required) + any create_budget params
+- **Returns:** `Budget`
+
+## Budget Response Fields
+
+- `id`, `name`, `amount`, `currency_id`, `cost_code`, `cost_type`, `archived`
+- `base_amount`, `base_rate` — converted to company base currency
+- `remaining_amount` — budget minus approved/paid POs
+- `summary` — spending summary
+- `approved_this_month` — amount approved in current month
+- `allow_anyone_to_approve_a_po` — bypass approver restrictions
+- `start_date`, `end_date` — budget period
+- `creator_id`, `approver_ids[]`, `department_ids[]`
+- `chart_of_account_id`, `chart_of_account_name`
+- `third_party_id_mappings` — external system IDs
+- `created_at`, `updated_at`
+
+## Date Format
+
+All date fields must match the company's `date_format` setting. Get it via `get_company_details` (pex-companies skill) from `company_setting.date_format`.

--- a/.claude/skills/pex-companies/SKILL.md
+++ b/.claude/skills/pex-companies/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: pex-companies
+description: >
+  ProcurementExpress company management, employee listing, user invitations, and approver
+  queries. Use when listing companies, switching the active company, viewing company details
+  and settings, managing employees and user invitations, or querying approvers. Routes to MCP
+  tools: list_companies, get_company, get_company_details, set_active_company, list_approvers,
+  list_all_approvers, list_employees, invite_user, get_invite_limit, list_pending_invites,
+  cancel_invite, resend_invite. Triggers on: company, switch company, employees, invite user,
+  approvers, company settings, custom fields, payment terms.
+---
+
+# ProcurementExpress Companies
+
+## Prerequisites
+
+Authenticate first (pex-auth skill). Most tools require an active company set via `set_active_company`.
+
+## Tools Reference
+
+### set_active_company
+Set the working company for all subsequent API calls. **Must be called before most operations.**
+- **Params:** `company_id` (required, string)
+- **Returns:** Confirmation text
+- This is a client-side operation (no API call)
+
+### list_companies
+List all companies the authenticated user belongs to.
+- **Params:** None
+- **Returns:** `CompanyDetail[]`
+
+### get_company
+Get company details by ID including settings, custom fields, and supported currencies.
+- **Params:** `id` (required, integer)
+- **Returns:** `CompanyDetail`
+
+### get_company_details
+Get details for the currently active company.
+- **Params:** None
+- **Returns:** `CompanyDetail`
+
+### list_employees
+List all active employees of the current company with their roles.
+- **Params:** None
+- **Requires:** companyadmin role
+- **Returns:** `Employee[]` — each has: id, email, name, roles[]
+
+### list_approvers
+List approvers for the current company. Returns empty if company uses approval flows.
+- **Params:** `department_id` (optional, integer) — filter by department
+- **Returns:** `Approver[]` — each has: id, email, name, approval_limit
+
+### list_all_approvers
+List all approvers regardless of auto-approval routing.
+- **Params:** None
+- **Returns:** `Approver[]`
+
+### invite_user
+Invite a user to the company.
+- **Params:**
+  - `email` (required, email format)
+  - `name` (required, string)
+  - `roles` (required, array) — valid values: `"companyadmin"`, `"approver"`, `"finance"`, `"teammember"`
+  - `approval_limit` (optional, number, default: 0)
+  - `department_ids` (optional, integer array)
+- **Requires:** Available invite slots (check with `get_invite_limit`)
+- **Returns:** Invitation result
+
+### get_invite_limit
+Check remaining invite slots for the company plan.
+- **Params:** None
+- **Returns:** `{ invite_limit_left, active_users, allowed_users }`
+
+### list_pending_invites
+List pending user invitations.
+- **Params:** None
+- **Requires:** companyadmin role
+- **Returns:** Array of pending invites (each has a `token` for cancel/resend)
+
+### cancel_invite
+Cancel a pending invitation.
+- **Params:** `token` (required, string) — from pending invite
+- **Requires:** companyadmin role
+
+### resend_invite
+Resend a pending invitation email.
+- **Params:** `token` (required, string) — from pending invite
+- **Requires:** companyadmin role
+
+## CompanyDetail Response Fields
+
+Key fields in `CompanyDetail`:
+- `id`, `name`, `is_locked`, `in_trial`, `trial_expired`, `remaining_trial_days`
+- `company_setting` — 40+ config fields including:
+  - `currency_id` — default currency
+  - `date_format` — date format used across all date fields in the API
+  - `gross_or_net` — whether amounts are gross or net
+  - `show_po_item_number`, `show_delivery_status`, `show_payment_status`
+  - `po_number_prefix`, `next_po_number`
+  - `invoice_enabled`, `invoice_approval_flow_enabled`
+  - `approval_flow_enabled` — whether approval flows are active
+- `custom_fields[]` — company custom fields with type, options, placement flags
+- `supported_currencies[]` — currencies enabled for this company
+- `payment_terms[]` — payment terms with due_days, day_of_month, term_type
+
+## User Roles
+
+| Role | Permissions |
+|------|------------|
+| `companyadmin` | Full admin access, manage users, settings |
+| `approver` | Approve/reject POs and invoices |
+| `finance` | Financial operations, override approvals, archive |
+| `teammember` | Create and view POs |

--- a/.claude/skills/pex-departments/SKILL.md
+++ b/.claude/skills/pex-departments/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: pex-departments
+description: >
+  ProcurementExpress department management. Use when listing, viewing, creating, or updating
+  departments (organizational units). Routes to MCP tools: list_departments, get_department,
+  create_department, update_department. Triggers on: department, division, organizational unit,
+  department users, department budgets.
+---
+
+# ProcurementExpress Departments
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+
+## Tools Reference
+
+### list_departments
+List departments. By default returns only departments the current user has access to.
+- **Params:**
+  - `archived` (optional, boolean, default: false)
+  - `company_specific` (optional, boolean) — true to list ALL company departments regardless of user access
+- **Returns:** `Department[]`
+
+### get_department
+Get a specific department by ID.
+- **Params:** `id` (required, integer)
+- **Returns:** `Department`
+
+### create_department
+Create a new department.
+- **Params:**
+  - `name` (required, string)
+  - `contact_person` (optional, string)
+  - `phone_number` (optional, string)
+  - `email` (optional, string)
+  - `address` (optional, string)
+  - `tax_number` (optional, string)
+  - `budget_ids` (optional, integer array) — budgets to associate
+  - `user_ids` (optional, integer array) — users to assign
+- **Returns:** `Department`
+
+### update_department
+Update an existing department.
+- **Params:** `id` (required) + any create_department params + `archived` (optional, boolean)
+- **Returns:** `Department`
+
+## Department Response Fields
+
+- `id`, `name`, `company_id`, `archived`
+- `contact_person`, `tax_number`, `phone_number`, `address`, `email`
+- `supplier_ids[]` — associated supplier IDs
+- `budget_ids[]` — associated budget IDs
+- `created_at`, `updated_at`
+
+## Relationships
+
+- Departments contain users and budgets
+- Departments can restrict which suppliers are available
+- POs and invoices can be filtered by department
+- Approvers can be filtered by department (pex-companies `list_approvers`)

--- a/.claude/skills/pex-invoices/SKILL.md
+++ b/.claude/skills/pex-invoices/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: pex-invoices
+description: >
+  ProcurementExpress invoice management. Covers creating, updating, accepting, approving,
+  rejecting, cancelling, archiving invoices, and adding comments. Handles the full invoice
+  lifecycle from receipt through approval to settlement. Routes to MCP tools: list_invoices,
+  get_invoice, create_invoice, update_invoice, accept_invoice, approve_invoice, reject_invoice,
+  cancel_invoice, archive_invoice, dearchive_invoice, rerun_invoice_approval_flow,
+  add_invoice_comment. Triggers on: invoice, bill, invoice approval, invoice status,
+  awaiting review, outstanding invoice, ready to pay, invoice comment, invoice line items.
+---
+
+# ProcurementExpress Invoices
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+Invoices must be enabled for the company (`company_setting.invoice_enabled`).
+
+## Core Tools
+
+### list_invoices
+List invoices with pagination and filters.
+- **Params:**
+  - `page` (optional, integer, default: 1)
+  - `per_page` (optional, integer) — allowed: 10, 20, 50, 100
+  - `search` (optional) — matches invoice number, supplier name
+  - `invoice_statuses_filter` (optional) — `"awaiting_review"`, `"outstanding"`, `"ready_to_pay"`, `"settled"`, `"cancelled"`
+  - `supplier_id`, `requester_id`, `approver_id`, `department_id` (all optional, integer)
+  - `archived` (optional, boolean, default: false)
+  - `invoice_date_filter` (optional) — `"last 7days"`, `"last 30days"`, `"last 60days"`, `"last 90days"`, `"last 180days"`, `"last 1year"`, `"current_month"`, `"current_year"`, `"last_month"`, `"last_year"`
+  - `sage_exported` (optional, boolean) — filter by Sage export status
+  - `sort` (optional), `direction` (optional, `"asc"` or `"desc"`)
+- **Returns:** `{ invoices: Invoice[], meta: PaginationMeta }`
+
+### get_invoice
+Get invoice details including line items, linked POs, comments, and payment history.
+- **Params:** `id` (required, integer)
+- **Returns:** `Invoice`
+
+### create_invoice
+Create a new invoice. If company has "create invoice in awaiting review" enabled, starts in awaiting_review status.
+- **Params:**
+  - `invoice_number` (optional, string)
+  - `issue_date`, `uploaded_date`, `received_date`, `due_date` (optional, string — company date_format)
+  - `gross_amount` (optional, number)
+  - `currency_id` (optional, integer)
+  - `supplier_id` (optional, integer)
+  - `standalone_invoice` (optional, boolean) — true if not linked to any PO
+  - `payment_term_id` (optional, integer) — payment terms from company settings
+  - `selected_purchase_order_ids` (optional, integer array) — PO IDs to link
+  - `line_items` (optional, array) — see [references/line-items.md](references/line-items.md)
+  - `custom_field_values_attributes` (optional, array) — invoice-level custom field values:
+    - `id` (optional, integer — for updates), `value` (required, string), `custom_field_id` (required, integer)
+    - Get available custom fields from `get_company_details` (pex-companies) → `custom_fields[]`
+- **Returns:** `Invoice`
+
+### update_invoice
+Update an existing invoice.
+- **Params:** `id` (required) + any create params
+- For line items: include `id` to update, `_destroy: true` to remove
+- **Returns:** `Invoice`
+
+## Approval Lifecycle Tools
+
+### accept_invoice
+Accept an invoice in awaiting_review status (moves to outstanding).
+- **Params:** `id` (required, integer)
+
+### approve_invoice
+Approve an invoice (requires invoice approval permission).
+- **Params:** `id` (required, integer)
+
+### reject_invoice
+Reject an invoice (requires invoice approval permission).
+- **Params:** `id` (required, integer)
+
+### cancel_invoice
+Cancel an invoice (requires cancel permission).
+- **Params:** `id` (required, integer)
+
+### archive_invoice
+Archive an invoice (requires archive permission).
+- **Params:** `id` (required, integer)
+
+### dearchive_invoice
+Restore an archived invoice.
+- **Params:** `id` (required, integer)
+
+### rerun_invoice_approval_flow
+Rerun the approval flow when rules have changed.
+- **Params:** `id` (required, integer)
+
+## Comment Tool
+
+### add_invoice_comment
+Add a comment to an invoice.
+- **Params:** `invoice_id` (required, integer), `comment` (required, string)
+
+## Invoice Status Flow
+
+```
+awaiting_review → (accept_invoice) → outstanding → (approve_invoice) → ready_to_pay → (payment) → settled
+                                    → (reject_invoice) → rejected
+                                    → (cancel_invoice) → cancelled
+```
+
+If `invoice_approval_flow_enabled`, the approval flow determines the approval path automatically.
+
+## Invoice Response Fields
+
+Key fields in `Invoice`:
+- `id`, `invoice_number`, `status`, `gross_amount`, `net_amount`
+- `issue_date`, `uploaded_date`, `received_date`, `due_date`, `validation_date`
+- `supplier_id`, `supplier_name`, `currency`
+- `standalone_invoice` — whether linked to POs
+- `confidence_score`, `digital_invoice` — AI extraction confidence
+- `invoice_line_items[]` — line items (see [references/line-items.md](references/line-items.md))
+- `purchase_order_summaries[]` — linked PO summaries
+- `supplier_invoice_uploads[]` — attached invoice files
+- `invoice_histories[]` — status change history
+- `invoice_comments[]` — comments with creator info
+- `payments[]` — payment records
+- Actions: `can_accept`, `can_approve`, `can_reject`, `can_cancel`, `can_archive`, `can_dearchive`
+- `payment_terms_list[]` — available payment terms

--- a/.claude/skills/pex-invoices/references/line-items.md
+++ b/.claude/skills/pex-invoices/references/line-items.md
@@ -1,0 +1,55 @@
+# Invoice Line Item Schema
+
+## Creating/Updating Line Items
+
+Each line item in the `line_items` array accepts:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | integer | For updates | Existing line item ID |
+| `description` | string | No | Item description |
+| `unit_price` | number | No | Unit price |
+| `quantity` | number | No | Quantity |
+| `vat` | number | No | VAT/tax percentage |
+| `net_amount` | number | No | Net amount |
+| `sequence_no` | integer | No | Display order |
+| `tax_rate_id` | integer | No | Tax rate ID (from pex-settings) |
+| `chart_of_account_id` | integer | No | GL code (from pex-settings) |
+| `qbo_customer_id` | integer | No | QuickBooks customer |
+| `quickbooks_class_id` | integer | No | QuickBooks class |
+| `qbo_line_description` | string | No | QuickBooks line description override |
+| `purchase_order_id` | integer | No | Link to a specific PO |
+| `purchase_order_item_id` | integer | No | Link to a specific PO line item |
+| `billable_status` | string | No | Billable status for QuickBooks |
+| `_destroy` | boolean | No | Set true to delete (updates only) |
+| `custom_field_values_attributes` | array | No | Line-item-level custom field values: `[{id?, value, custom_field_id}]` |
+
+## Line Item Response Fields
+
+Each `InvoiceLineItem` in the response contains:
+
+- `id`, `sequence_no`, `description`, `unit_price`, `quantity`
+- `vat`, `gross_amount`, `net_amount` — calculated amounts
+- `tax_rate_id`, `tax_exception` — tax details
+- `chart_of_account` — GL code details (id, name, display_name)
+- `qbo_customer` — QuickBooks customer details
+- `quickbooks_class` — QuickBooks class details
+- `invoice_id`, `purchase_order_id`, `purchase_order_item_id` — relationships
+
+## Linking to Purchase Orders
+
+Invoice line items can be linked to PO line items for three-way matching:
+- Set `purchase_order_id` to link to a PO
+- Set `purchase_order_item_id` to link to a specific PO line item
+- Also set `selected_purchase_order_ids` on the invoice itself
+
+This enables matching invoice amounts against PO amounts for variance detection.
+
+## Reference Data
+
+For IDs used in line items, use pex-settings tools:
+- `list_tax_rates` → `tax_rate_id`
+- `list_chart_of_accounts` → `chart_of_account_id`
+- `list_qbo_customers` → `qbo_customer_id`
+- `list_qbo_classes` → `quickbooks_class_id`
+- Custom field IDs from `get_company_details` (pex-companies) → `custom_fields[]`

--- a/.claude/skills/pex-payments/SKILL.md
+++ b/.claude/skills/pex-payments/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: pex-payments
+description: >
+  ProcurementExpress payment management. Use when creating or viewing payments to settle
+  invoices and purchase orders. Routes to MCP tools: get_payment, create_payment,
+  create_po_payment. Triggers on: payment, pay invoice, pay purchase order, settle,
+  bank transfer, payment record, payment type.
+---
+
+# ProcurementExpress Payments
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+The payments feature may be feature-flagged — contact sales if `create_payment` returns an error.
+
+## Tools Reference
+
+### get_payment
+Get payment details by ID including linked invoices and POs.
+- **Params:** `id` (required, integer)
+- **Returns:** `Payment`
+
+### create_payment
+Create a payment to settle invoices and/or purchase orders.
+- **Params:**
+  - `supplier_id` (required, integer)
+  - `ptype` (required, enum) — payment type, one of:
+    - `"bank_transfer"`, `"card"`, `"credit_card"`, `"check"`, `"cash"`, `"one_time_card"`, `"letter_of_credit"`, `"other"`
+  - `date` (required, string) — must match company `date_format` setting
+  - `currency_id` (required, integer)
+  - `amount` (required, number) — total payment amount
+  - `reference` (optional, string) — payment reference number
+  - `payment_mode` (optional, string)
+  - `status` (optional, string)
+  - `invoices` (optional, array) — invoices to settle:
+    - `invoice_id` (required, integer)
+    - `gross_amount` (required, number) — amount applied to this invoice
+  - `purchase_orders` (optional, array) — POs to settle:
+    - `purchase_order_id` (required, integer)
+    - `budget_id` (optional, integer)
+    - `gross_amount` (required, number) — amount applied to this PO
+  - `comments` (optional, array) — payment comments:
+    - `comment` (required, string)
+- **Returns:** `Payment`
+
+### create_po_payment
+Create a payment for a specific purchase order with optional item-level breakdown.
+- **Params:**
+  - `purchase_order_id` (required, integer)
+  - `amount` (optional, number) — total payment (if not using item-level)
+  - `note` (optional, string)
+  - `item_payments` (optional, array) — item-level payments:
+    - `purchase_order_item_id` (required, integer) — PO line item ID
+    - `amount` (required, number) — amount for this item
+- **Returns:** Payment result
+
+## Payment Response Fields
+
+- `id`, `reference`, `status`, `ptype`, `date`, `amount`
+- `currency` — currency details
+- `supplier` — supplier summary
+- `user` — creator details
+- `invoices[]` — linked invoice summaries
+- `npayment_comments[]` — payment comments (id, comment, creator_id, system_generated)
+
+## Workflow: Settle an Invoice
+
+```
+1. get_invoice (pex-invoices) → get invoice details, supplier_id, gross_amount
+2. create_payment → with supplier_id, amount, ptype, invoices array
+```
+
+## Workflow: Pay a Purchase Order
+
+```
+Option A: create_po_payment → simple PO payment with optional item breakdown
+Option B: create_payment → with purchase_orders array (can combine with invoices)
+```

--- a/.claude/skills/pex-purchase-orders/SKILL.md
+++ b/.claude/skills/pex-purchase-orders/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: pex-purchase-orders
+description: >
+  ProcurementExpress purchase order (PO) management — the core procurement workflow. Covers
+  creating, updating, approving, rejecting, cancelling, archiving, and deleting POs. Also
+  handles delivery tracking, PDF generation, forwarding POs to suppliers, and adding comments.
+  Routes to MCP tools: list_purchase_orders, get_purchase_order, create_purchase_order,
+  update_purchase_order, approve_purchase_order, reject_purchase_order,
+  override_and_approve_purchase_order, cancel_purchase_order, archive_purchase_order,
+  delete_purchase_order, generate_purchase_order_pdf, get_pending_request_count,
+  receive_purchase_order_items, cancel_receiving_items, complete_purchase_order_delivery,
+  add_purchase_order_comment, forward_purchase_order, list_send_to_supplier_templates.
+  Triggers on: purchase order, PO, create PO, approve PO, reject PO, PO delivery, PO PDF,
+  forward PO, PO comment, pending approvals, line items, PO status.
+---
+
+# ProcurementExpress Purchase Orders
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+
+## Core Tools
+
+### list_purchase_orders
+List POs with pagination, search, and filters. Always returns paginated results.
+- **Params:**
+  - `page` (optional, integer, default: 1)
+  - `search` (optional) — matches PO number, supplier name, notes, line item descriptions
+  - `status` (optional) — `"draft"`, `"pending"`, `"approved"`, `"rejected"`, `"cancelled"`, `"paid"`
+  - `delivery_status` (optional) — `"not_delivered"`, `"partially_delivered"`, `"complete_delivered"`
+  - `payment_status` (optional) — `"unpaid"`, `"partially_paid"`, `"paid"`, `"invoice_received"`
+  - `supplier_id`, `requester_id`, `budget_id`, `filter_dept_id`, `approver_id` (all optional, integer)
+  - `archived` (optional, boolean, default: false)
+  - `date_filter` (optional) — `"current_month"`, `"current_year"`, `"last_month"`, `"last_year"`
+  - `from`, `to` (optional) — custom date range (company date_format)
+  - `updated_after` (optional) — ISO datetime for incremental sync
+  - `sort` (optional), `direction` (optional, `"asc"` or `"desc"`)
+  - `requests` (optional, boolean) — include pending approval requests
+  - `bell` (optional, boolean) — with requests=true, show only bell notification items
+- **Returns:** `{ purchase_orders: PurchaseOrder[], meta: PaginationMeta }`
+
+### get_purchase_order
+Get PO details including line items, comments, approvals, and status flags.
+- **Params:** `id` (required, string) — accepts numeric ID, approval-key, or slug
+- **Returns:** `PurchaseOrder`
+
+### create_purchase_order
+Create a new PO. At least one line item is required. See [references/line-items.md](references/line-items.md).
+- **Params:**
+  - `commit` (required) — `"Send"` (submit for approval) or `"Draft"` (save as draft)
+  - `creator_id` (required, integer) — get from `get_current_user`
+  - `line_items` (required, array, min 1) — see [references/line-items.md](references/line-items.md)
+  - `department_id` (optional, integer)
+  - `supplier_id` (optional, integer) — existing supplier
+  - `supplier_name` (optional) — display name for existing supplier
+  - `new_supplier_name` (optional) — create a new supplier inline
+  - `currency_id` (optional, integer) — defaults to company/user currency
+  - `iso_code` (optional) — alternative to currency_id (e.g. "USD")
+  - `notes` (optional)
+  - `submitted_on` (optional) — date in company date_format
+  - `on_behalf_of` (optional, integer) — create on behalf of another user (companyadmin only)
+  - `approver_list` (optional, integer array) — override default approvers
+  - `custom_field_values_attributes` (optional, array) — PO-level custom field values:
+    - `id` (optional, integer — for updates), `value` (required, string), `custom_field_id` (required, integer)
+    - Get available custom fields from `get_company_details` (pex-companies) → `custom_fields[]`
+- **Returns:** `PurchaseOrder`
+
+### update_purchase_order
+Update an existing PO. Use `commit: "Send"` to submit a draft for approval.
+- **Params:** `id` (required, string) + any create params (all optional)
+- For line items: include `id` to update existing, `_destroy: true` to remove
+- **Returns:** `PurchaseOrder`
+
+## Approval Tools
+
+### approve_purchase_order
+- **Params:** `id` (required, string), `token` (required, string — accept token from approver_requests)
+- Get the token from `get_purchase_order` response → `approver_requests[].accept_token`
+
+### reject_purchase_order
+- **Params:** `id` (required, string), `token` (required, string — reject token from approver_requests)
+- Get the token from `get_purchase_order` response → `approver_requests[].reject_token`
+
+### override_and_approve_purchase_order
+Override and approve without a token. Requires finance role.
+- **Params:** `id` (required, string)
+
+### get_pending_request_count
+Get count of pending approval requests for the current user.
+- **Params:** None
+- **Returns:** Text with pending count
+
+## Lifecycle Tools
+
+### cancel_purchase_order
+- **Params:** `id` (required, string). Requires cancel permission.
+
+### archive_purchase_order
+Toggle archive status. Requires finance role. Call again to dearchive.
+- **Params:** `id` (required, string)
+
+### delete_purchase_order
+Permanently delete. Requires destroy permission.
+- **Params:** `id` (required, string)
+
+## Delivery Tools
+
+### receive_purchase_order_items
+Mark line items as received (partial or full delivery).
+- **Params:**
+  - `id` (required, string) — PO ID
+  - `items` (required, array) — `[{ id: lineItemId, quantity: receivedQty }, ...]`
+  - `delivered_on` (required, string) — delivery date in company date_format
+  - `notes` (optional)
+
+### cancel_receiving_items
+Cancel all received deliveries, reverting to not_delivered status.
+- **Params:** `id` (required, string)
+
+### complete_purchase_order_delivery
+Mark PO as fully delivered.
+- **Params:** `id` (required, string)
+
+## Communication Tools
+
+### add_purchase_order_comment
+- **Params:** `purchase_order_id` (required, integer), `comment` (required, string)
+- **Returns:** `PurchaseOrderComment` with formatted dates and creator info
+
+### forward_purchase_order
+Forward PO to supplier(s) via email with PDF attached.
+- **Params:**
+  - `purchase_order_id` (required, integer)
+  - `emails` (required, string) — comma-separated recipient emails
+  - `cc` (optional) — CC email (defaults to PO creator's email)
+  - `note` (optional) — email body text
+  - `email_subject` (optional)
+  - `uploads` (optional, integer array) — upload IDs to attach
+
+### list_send_to_supplier_templates
+List email templates for forwarding POs.
+- **Returns:** `SendToSupplierTemplate[]` — id, label, text, is_default, template_name
+
+### generate_purchase_order_pdf
+Generate a PDF and get download link.
+- **Params:** `id` (required, string)
+- **Returns:** `{ pdf_link: string }`
+
+## PO Response Fields
+
+Key fields in `PurchaseOrder`:
+- `id`, `po_number`, `slug`, `status`, `notes`, `total_gross_amount`, `total_net_amount`
+- `supplier_name`, `supplier_id`, `department_name`, `department_id`
+- `currency_id`, `creator_id`, `submitted_on`, `archived`
+- `delivery_status`, `payment_status`
+- `purchase_order_items[]` — line items (see [references/line-items.md](references/line-items.md))
+- `purchase_order_comments[]` — comments with creator info
+- `approver_requests[]` — approval status with accept/reject tokens
+- `approvers_with_flows[]` — approval flow step details
+- `compliance_checks[]` — compliance status with violations
+- `custom_field_values[]` — custom field data
+- `uploads[]` — attached files
+
+## Common Workflows
+
+See [references/workflows.md](references/workflows.md) for step-by-step guides.

--- a/.claude/skills/pex-purchase-orders/references/line-items.md
+++ b/.claude/skills/pex-purchase-orders/references/line-items.md
@@ -1,0 +1,53 @@
+# PO Line Item Schema
+
+## Creating/Updating Line Items
+
+Each line item in the `line_items` array accepts:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | integer | For updates | Existing line item ID (omit for new items) |
+| `description` | string | Yes | Item description |
+| `quantity` | number | Yes | Quantity |
+| `unit_price` | number | Yes | Unit price |
+| `budget_id` | integer | No | Budget to charge against |
+| `vat` | number | No | VAT/tax percentage |
+| `tax_rate_id` | integer | No | Tax rate ID (from pex-settings) |
+| `item_number` | string | No | Item number (if company has show_po_item_number enabled) |
+| `sequence_no` | integer | No | Display order |
+| `department_id` | integer | No | Department for this line item |
+| `product_id` | integer | No | Product ID (auto-fills description, SKU, unit_price from catalog) |
+| `chart_of_account_id` | integer | No | GL code (from pex-settings) |
+| `qbo_customer_id` | integer | No | QuickBooks customer |
+| `quickbooks_class_id` | integer | No | QuickBooks class |
+| `qbo_line_description` | string | No | QuickBooks line description override |
+| `archived` | boolean | No | Archive this line item |
+| `_destroy` | boolean | No | Set true to delete this line item (updates only) |
+| `custom_field_values_attributes` | array | No | Line-item-level custom field values: `[{id?, value, custom_field_id}]` |
+
+## Line Item Response Fields
+
+Each `PurchaseOrderItem` in the response contains:
+
+- `id`, `description`, `quantity`, `unit_price`, `item_number`, `sequence_no`
+- `budget_id`, `budget_name` — associated budget
+- `gross_amount`, `net_amount`, `vat` — calculated amounts
+- `tax_rate_id` — applied tax rate
+- `product_id` — linked product
+- `received_quantity` — quantity received so far
+- `chart_of_account` — GL code details (id, name, display_name)
+- `qbo_customer` — QuickBooks customer details
+- `quickbooks_class` — QuickBooks class details
+- `custom_field_values[]` — custom field data for this line item
+- `department_id`, `purchase_order_id`
+
+## Tips
+
+- When using `product_id`, the product's description, SKU, and unit_price will be used as defaults
+- To update existing line items, include their `id`. To add new items, omit `id`
+- To remove a line item during update, include `id` and `_destroy: true`
+- The `budget_id` determines which budget is charged when the PO is approved
+- If the company uses `gross_or_net` setting, amounts are calculated accordingly
+- Custom fields can be set at both PO level and line item level via `custom_field_values_attributes`
+- Get available custom field IDs from `get_company_details` (pex-companies) → `custom_fields[]`
+- For reference data IDs: use pex-settings tools (`list_tax_rates`, `list_chart_of_accounts`, `list_qbo_customers`, `list_qbo_classes`)

--- a/.claude/skills/pex-purchase-orders/references/workflows.md
+++ b/.claude/skills/pex-purchase-orders/references/workflows.md
@@ -1,0 +1,74 @@
+# PO Workflows
+
+## Create and Submit a PO
+
+```
+1. get_current_user → get creator_id
+2. list_departments → pick department_id
+3. list_suppliers or get_top_suppliers → pick supplier_id
+4. list_budgets (filter by department_id) → pick budget_id for line items
+5. list_currencies → confirm currency_id (optional)
+6. create_purchase_order with commit="Send", creator_id, supplier_id, line_items
+```
+
+## Create a Draft PO
+
+Same as above but use `commit="Draft"`. Submit later with `update_purchase_order` using `commit="Send"`.
+
+## Approve a PO
+
+```
+1. get_purchase_order → find approver_requests[]
+2. Find request where approver matches current user
+3. approve_purchase_order with id and token=request.accept_token
+```
+
+## Reject a PO
+
+```
+1. get_purchase_order → find approver_requests[]
+2. reject_purchase_order with id and token=request.reject_token
+```
+
+## Track Delivery
+
+```
+1. get_purchase_order → see purchase_order_items with received_quantity
+2. receive_purchase_order_items → record partial delivery
+   - items: [{ id: itemId, quantity: receivedQty }]
+   - delivered_on: delivery date
+3. Repeat step 2 for additional deliveries
+4. complete_purchase_order_delivery → mark as fully delivered
+```
+
+## Forward PO to Supplier
+
+```
+1. list_send_to_supplier_templates → get email template
+2. get_supplier → get supplier email
+3. forward_purchase_order → send with emails, note from template
+```
+
+## Generate PDF
+
+```
+1. generate_purchase_order_pdf → returns { pdf_link: "..." }
+2. Share the pdf_link with the user
+```
+
+## Review Pending Approvals
+
+```
+1. get_pending_request_count → see how many POs need approval
+2. list_purchase_orders with requests=true → get POs pending approval
+3. For each PO: approve or reject using tokens
+```
+
+## Create PO on Behalf of Another User
+
+Requires companyadmin role. The `on_behalf_of` user must be an active employee.
+
+```
+1. list_employees → find user ID
+2. create_purchase_order with on_behalf_of=userId, creator_id=your own ID
+```

--- a/.claude/skills/pex-settings/SKILL.md
+++ b/.claude/skills/pex-settings/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: pex-settings
+description: >
+  ProcurementExpress settings, reference data, and integrations. Covers tax rates, webhooks,
+  currencies, chart of accounts (GL codes), and QuickBooks (QBO) customers/classes. Use when
+  managing tax rates, setting up webhooks for PO events, querying currencies, looking up
+  chart of accounts or GL codes, or working with QuickBooks data. Routes to MCP tools:
+  list_tax_rates, get_tax_rate, create_tax_rate, update_tax_rate, list_webhooks, get_webhook,
+  create_webhook, update_webhook, delete_webhook, list_currencies, list_all_currencies,
+  list_chart_of_accounts, get_chart_of_account, list_qbo_customers, get_qbo_customer,
+  list_qbo_classes, get_qbo_class. Triggers on: tax rate, VAT, webhook, delete webhook,
+  currency, chart of accounts, GL code, QuickBooks, QBO customer, QBO class,
+  accounting integration.
+---
+
+# ProcurementExpress Settings & Reference Data
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+
+## Tax Rate Tools
+
+### list_tax_rates
+List tax rates for the current company.
+- **Params:** `archived` (optional, boolean, default: false)
+- **Returns:** `TaxRate[]` — each has: id, name, value, archived, company_id, tax_type, tax_rate_items[]
+
+### get_tax_rate
+- **Params:** `id` (required, integer)
+- **Returns:** `TaxRate`
+
+### create_tax_rate
+- **Params:** `name` (required, string, e.g. "VAT 20%"), `value` (required, number, e.g. 20)
+- **Returns:** `TaxRate`
+
+### update_tax_rate
+- **Params:** `id` (required) + `name`, `value`, `archived` (all optional)
+- **Returns:** `TaxRate`
+
+## Currency Tools
+
+### list_currencies
+List currencies enabled for the current company. Company default currency is listed first.
+- **Params:** None
+- **Returns:** `Currency[]` — each has: id, iso_code, iso_numeric, name, symbol
+
+### list_all_currencies
+List ALL available currencies globally (sorted by popularity if company is set).
+- **Params:** None
+- **Returns:** `Currency[]`
+
+## Webhook Tools
+
+Webhooks fire on PO lifecycle events. Each webhook sends an HTTP POST to the configured URL.
+
+### list_webhooks
+- **Params:** `archived` (optional, boolean, default: false)
+- **Returns:** `Webhook[]`
+
+### get_webhook
+- **Params:** `id` (required, integer)
+- **Returns:** `Webhook` — includes: id, name, url, event_type[], tested, response_code, webhook_attributes[]
+
+### create_webhook
+- **Params:**
+  - `name` (required, string)
+  - `url` (required, string) — handler URL
+  - `event_type` (required, string array) — one or more of:
+    - `"new_po"`, `"po_approved"`, `"po_delivered"`, `"po_paid"`, `"po_cancelled"`, `"po_update"`
+  - `authentication_header` (optional, string) — custom auth header value
+  - `json_wrapper` (optional, string) — root key for JSON payload
+  - `send_as_text` (optional, boolean) — send as text instead of JSON
+  - `basic_auth_uname` (optional, string) — basic auth username
+  - `basic_auth_pword` (optional, string) — basic auth password
+  - `webhook_attributes` (optional, array) — custom key-value pairs sent with each webhook:
+    - `attrib_type` (required), `key` (required), `value` (required)
+- **Returns:** `Webhook`
+
+### update_webhook
+- **Params:** `id` (required) + any create_webhook params + `archived` (optional, boolean)
+- For webhook_attributes updates: include `id` to update existing, `_destroy: true` to remove
+- **Returns:** `Webhook`
+
+### delete_webhook
+Permanently delete a webhook.
+- **Params:** `id` (required, integer)
+- **Returns:** Deletion confirmation
+
+## Chart of Accounts Tools (GL Codes)
+
+Used for accounting classification on PO/invoice line items.
+
+### list_chart_of_accounts
+- **Params:** `search` (optional), `page` (optional, integer), `per_page` (optional, integer)
+- **Returns:** `{ chart_of_accounts: ChartOfAccount[], meta: PaginationMeta }`
+
+### get_chart_of_account
+- **Params:** `id` (required, integer)
+- **Returns:** `ChartOfAccount` — id, name, classification, account_type, currency_code, account_number, display_name, archived
+
+## QuickBooks Tools
+
+### list_qbo_customers
+- **Params:** `search` (optional), `page` (optional), `per_page` (optional)
+- **Returns:** `{ qbo_customers: QboCustomer[], meta: PaginationMeta }`
+
+### get_qbo_customer
+- **Params:** `id` (required, integer)
+- **Returns:** `QboCustomer` — id, fully_qualified_name, archived
+
+### list_qbo_classes
+- **Params:** `search` (optional), `page` (optional), `per_page` (optional)
+- **Returns:** `{ quickbooks_classes: QboClass[], meta: PaginationMeta }`
+
+### get_qbo_class
+- **Params:** `id` (required, integer)
+- **Returns:** `QboClass` — id, fully_qualified_name, archived
+
+## Where Reference Data Is Used
+
+| Data | Used In |
+|------|---------|
+| Tax rates | PO line items (`tax_rate_id`), invoice line items, products |
+| Currencies | Budgets, POs, invoices, payments, suppliers |
+| Chart of accounts | PO line items, invoice line items, budgets |
+| QBO customers | PO line items, invoice line items |
+| QBO classes | PO line items, invoice line items, budgets |

--- a/.claude/skills/pex-suppliers/SKILL.md
+++ b/.claude/skills/pex-suppliers/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: pex-suppliers
+description: >
+  ProcurementExpress supplier and product management. Use when listing, viewing, creating, or
+  updating suppliers (vendors) and their products (catalog items). Routes to MCP tools:
+  list_suppliers, get_top_suppliers, get_supplier, create_supplier, update_supplier,
+  list_products, get_product, create_product, update_product. Triggers on: supplier, vendor,
+  product, catalog, SKU, top suppliers, supplier search, product list.
+---
+
+# ProcurementExpress Suppliers & Products
+
+## Prerequisites
+
+Authenticate (pex-auth) and set active company (pex-companies) first.
+
+## Supplier Tools
+
+### list_suppliers
+List suppliers with optional pagination, search, and filters.
+- **Params:**
+  - `page` (optional, integer) — enables pagination (20 per page). Without page, returns ALL suppliers
+  - `search` (optional, string) — search by supplier name
+  - `department_id` (optional, integer) — filter by department (also includes suppliers with no department)
+  - `archived` (optional, boolean, default: false)
+  - `show_mappings` (optional, boolean) — include third-party ID mappings
+- **Returns:** `Supplier[]` (no pagination) or `{ suppliers: Supplier[], meta: PaginationMeta }` (with pagination)
+
+### get_top_suppliers
+Get the user's most frequently used suppliers.
+- **Params:**
+  - `top` (optional, integer, default: 5) — number of suppliers to return
+  - `archived` (optional, boolean)
+- **Returns:** `Supplier[]`
+
+### get_supplier
+Get a specific supplier by ID.
+- **Params:** `id` (required, integer)
+- **Returns:** `Supplier`
+
+### create_supplier
+Create a new supplier. Name must be unique within the company.
+- **Params:**
+  - `name` (required, string, must be unique)
+  - `email` (optional, string)
+  - `address` (optional, string)
+  - `notes` (optional, string)
+  - `payment_details` (optional, string) — bank/payment info
+  - `phone_number` (optional, string)
+  - `tax_number` (optional, string)
+  - `contact_person` (optional, string)
+  - `uei` (optional, string) — Unique Entity Identifier for SAM.gov
+  - `cage_code` (optional, string) — CAGE code for government contracting
+  - `department_ids` (optional, integer array) — restrict supplier to specific departments
+- **Note:** If company has supplier approval enabled, creates a pending approval request instead
+- **Returns:** `Supplier`
+
+### update_supplier
+Update an existing supplier.
+- **Params:** `id` (required) + any create_supplier params + `archived` (optional, boolean)
+- **Returns:** `Supplier`
+
+## Product Tools
+
+Products are catalog items associated with a supplier. When creating PO line items, use `product_id` to auto-fill description, SKU, and unit price.
+
+### list_products
+List products with optional pagination and filters.
+- **Params:**
+  - `page` (optional, integer) — enables pagination
+  - `per_page` (optional, integer, default: 20)
+  - `supplier_id` (optional, integer) — filter by supplier
+  - `archived` (optional, boolean, default: false)
+- **Returns:** `Product[]` (no pagination) or `{ products: Product[], meta: PaginationMeta }` (with pagination)
+
+### get_product
+Get a specific product by ID.
+- **Params:** `id` (required, integer)
+- **Returns:** `Product`
+
+### create_product
+Create a new product associated with a supplier.
+- **Params:**
+  - `description` (required, string)
+  - `supplier_id` (required, integer) — must belong to an existing supplier
+  - `sku` (optional, string)
+  - `unit_price` (optional, number)
+- **Returns:** `Product`
+
+### update_product
+Update an existing product.
+- **Params:** `id` (required) + `description`, `sku`, `unit_price`, `supplier_id` (all optional)
+- **Returns:** `Product`
+
+## Supplier Response Fields
+
+- `id`, `name`, `company_id`, `archived`
+- `email`, `phone_number`, `address`, `contact_person`
+- `notes`, `payment_details`, `tax_number`
+- `payment_terms`, `currency_id`
+- `department_ids[]` — restricted departments
+- `external_vendor_id`, `third_party_id_mappings`
+- `created_at`, `updated_at`
+
+## Product Response Fields
+
+- `id`, `supplier_id`, `sku`, `description`, `unit_price`
+- `currency_id`, `archived`, `tax_rate_id`
+- `created_at`, `updated_at`
+
+## PaginationMeta Fields
+
+- `current_page`, `next_page`, `prev_page`, `total_pages`, `total_count`

--- a/.claude/tasks/todo.md
+++ b/.claude/tasks/todo.md
@@ -1,20 +1,24 @@
 # MCP Tools Update — Align with Rails API Implementation
 
-## Modules to Update
+## Modules Updated (all committed)
 
-- [ ] **1. Purchase Orders** — ID as string (supports id/slug/approval-key), missing filters (status, delivery_status, supplier_id, requester_id, budget_id, department, approver_id, date_filter, from/to, archived, payment_status, updated_after), missing actions (delete, generate_pdf, complete_delivery, cancel_receiving_items), create/update missing fields (on_behalf_of, submitted_on, new_supplier_name, iso_code, line item fields: department_id, chart_of_account_id, qbo_customer_id, quickbooks_class_id, product_id, qbo_line_description)
-- [ ] **2. Invoices** — Missing filters (per_page, search query, invoice_statuses_filter, department_id, sort, direction, sage_exported), create has wrong company_id param, missing fields (uploaded_date, received_date, standalone_invoice, payment_term_id, selected_purchase_order_ids, line item fields), update missing many fields, add rerun_approval_flow, fix comment param nesting
-- [ ] **3. Budgets** — No pagination in controller (remove page param), remove only_active, add show_mappings, create/update missing fields (chart_of_account_id, qbo_class, custom_field_values_attributes)
-- [ ] **4. Suppliers** — Add search param, show_mappings, pagination is optional (only when page present), create/update missing uei/cage_code, fix department_ids nesting
-- [ ] **5. Products** — Add page/per_page for pagination, supplier_id required on create
-- [ ] **6. Departments** — Mostly correct, minor description improvements
-- [ ] **7. Companies** — list_approvers department_id should be optional, invite_user missing approval_limit/department_ids, add pending_invites/cancel_invite/resend_invite/invite_limit_left
-- [ ] **8. Tax Rates** — Add archived filter to list, remove company_id from create (set from current_company)
-- [ ] **9. Webhooks** — Add authentication_header, webhook_attributes_attributes
-- [ ] **10. Payments** — npayments: add payment_mode/status/po-linked payments/comments. PO payment: add amount field
-- [ ] **11. Comments** — Fix PO comment path (purchase_orders not purchase_order), fix invoice comment param nesting
-- [ ] **12. Supplementary** — Add page/per_page to chart_of_accounts/qbo_customers/qbo_classes, fix forward emails type
-- [ ] **13. Approval Flows** — Add update_approval_flow, publish, unpublish actions
-- [ ] **14. Users** — Add first_name/last_name, password_confirmation
-- [ ] **15. Update README** — Reflect all changes
-- [ ] **16. Run tests & build** — Ensure everything passes
+- [x] **1. Purchase Orders** — String ID, 15+ filters, custom_field_values_attributes (PO + line item level)
+- [x] **2. Invoices** — Enum filters (status, date), custom_field_values_attributes (invoice + line item level), rerun_approval_flow
+- [x] **3. Budgets** — No pagination, custom_field_values_attributes, show_mappings
+- [x] **4. Suppliers** — search, conditional pagination, uei/cage_code
+- [x] **5. Products** — page/per_page, supplier_id required on create
+- [x] **6. Departments** — Description improvements
+- [x] **7. Companies** — 5 new tools (details, invite_limit, pending_invites, cancel/resend invite)
+- [x] **8. Tax Rates** — Fixed archived filter bug
+- [x] **9. Webhooks** — Fixed archived filter, added delete_webhook
+- [x] **10. Payments** — Enhanced create, added get_payment
+- [x] **11. Comments** — Fixed plural path, invoice comment nesting
+- [x] **12. Supplementary** — Pagination, detail endpoints, forward emails type
+- [x] **13. Approval Flows** — Update, publish/unpublish (PATCH), versions, show_entity, rerun_approval_flows, operator enum
+- [x] **14. Users** — first_name/last_name, password_confirmation
+- [x] **15. API Client** — Added patch() method
+- [x] **16. Tests & Build** — All 49 tests passing, build clean
+
+## Remaining
+- [ ] **17. Update README** — Reflect all tool changes
+- [ ] **18. Final review & commit** — Commit iteration 2 changes

--- a/.claude/tasks/todo.md
+++ b/.claude/tasks/todo.md
@@ -1,0 +1,20 @@
+# MCP Tools Update — Align with Rails API Implementation
+
+## Modules to Update
+
+- [ ] **1. Purchase Orders** — ID as string (supports id/slug/approval-key), missing filters (status, delivery_status, supplier_id, requester_id, budget_id, department, approver_id, date_filter, from/to, archived, payment_status, updated_after), missing actions (delete, generate_pdf, complete_delivery, cancel_receiving_items), create/update missing fields (on_behalf_of, submitted_on, new_supplier_name, iso_code, line item fields: department_id, chart_of_account_id, qbo_customer_id, quickbooks_class_id, product_id, qbo_line_description)
+- [ ] **2. Invoices** — Missing filters (per_page, search query, invoice_statuses_filter, department_id, sort, direction, sage_exported), create has wrong company_id param, missing fields (uploaded_date, received_date, standalone_invoice, payment_term_id, selected_purchase_order_ids, line item fields), update missing many fields, add rerun_approval_flow, fix comment param nesting
+- [ ] **3. Budgets** — No pagination in controller (remove page param), remove only_active, add show_mappings, create/update missing fields (chart_of_account_id, qbo_class, custom_field_values_attributes)
+- [ ] **4. Suppliers** — Add search param, show_mappings, pagination is optional (only when page present), create/update missing uei/cage_code, fix department_ids nesting
+- [ ] **5. Products** — Add page/per_page for pagination, supplier_id required on create
+- [ ] **6. Departments** — Mostly correct, minor description improvements
+- [ ] **7. Companies** — list_approvers department_id should be optional, invite_user missing approval_limit/department_ids, add pending_invites/cancel_invite/resend_invite/invite_limit_left
+- [ ] **8. Tax Rates** — Add archived filter to list, remove company_id from create (set from current_company)
+- [ ] **9. Webhooks** — Add authentication_header, webhook_attributes_attributes
+- [ ] **10. Payments** — npayments: add payment_mode/status/po-linked payments/comments. PO payment: add amount field
+- [ ] **11. Comments** — Fix PO comment path (purchase_orders not purchase_order), fix invoice comment param nesting
+- [ ] **12. Supplementary** — Add page/per_page to chart_of_accounts/qbo_customers/qbo_classes, fix forward emails type
+- [ ] **13. Approval Flows** — Add update_approval_flow, publish, unpublish actions
+- [ ] **14. Users** — Add first_name/last_name, password_confirmation
+- [ ] **15. Update README** — Reflect all changes
+- [ ] **16. Run tests & build** — Ensure everything passes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -144,6 +144,14 @@ export class ApiClient {
     return this.request<T>("PUT", path, body, extraHeaders);
   }
 
+  async patch<T>(
+    path: string,
+    body?: Record<string, unknown>,
+    extraHeaders?: Record<string, string>,
+  ): Promise<T> {
+    return this.request<T>("PATCH", path, body, extraHeaders);
+  }
+
   async delete<T>(path: string, extraHeaders?: Record<string, string>): Promise<T> {
     return this.request<T>("DELETE", path, undefined, extraHeaders);
   }

--- a/src/tools/approval-flows.ts
+++ b/src/tools/approval-flows.ts
@@ -5,30 +5,35 @@ import { jsonResponse, withErrorHandling } from "../tool-helpers.js";
 import type { ApprovalFlow, PaginationMeta } from "../types.js";
 
 const approvalConditionSchema = z.object({
-  property: z.string().describe("Condition property (budget, department, supplier, requester, gross_amount, net_amount, custom_field_xxx)"),
+  id: z.number().int().optional().describe("Condition ID (for updates)"),
+  property: z.string().describe("Condition property: budget, department, supplier, requester, gross_amount, net_amount, or custom_field_<id>"),
   operator: z.string().describe("Operator: equals(0), not_equals(1), greater_than(2), less_than(3), contains(4), not_contains(5)"),
-  value: z.string().describe("Condition value (single ID or comma-separated IDs)"),
-  custom_field_id: z.number().int().optional().describe("Custom field ID (for custom_field properties)"),
+  value: z.string().describe("Condition value (single ID or comma-separated IDs for contains/not_contains)"),
+  custom_field_id: z.number().int().optional().describe("Custom field ID (when property is custom_field_<id>)"),
+  _destroy: z.boolean().optional().describe("Set true to remove this condition on update"),
 });
 
 const approvalStepSchema = z.object({
-  step_no: z.number().int().describe("Step number"),
-  all_should_approve: z.boolean().describe("Whether all approvers in step must approve"),
-  approver_user_ids: z.array(z.number().int()).describe("Approver user IDs"),
-  conditions: z.array(approvalConditionSchema).optional().describe("Step-level conditions"),
+  id: z.number().int().optional().describe("Step ID (for updates)"),
+  step_no: z.number().int().describe("Step number (execution order)"),
+  all_should_approve: z.boolean().describe("True = all approvers in step must approve; false = any one approver suffices"),
+  approver_user_ids: z.array(z.number().int()).describe("User IDs of approvers for this step"),
+  conditions: z.array(approvalConditionSchema).optional().describe("Step-level conditions (all must match for step to activate)"),
+  _destroy: z.boolean().optional().describe("Set true to remove this step on update"),
 });
 
 export function registerApprovalFlowTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_approval_flows",
     {
-      description: "List approval flows with search and pagination",
+      description:
+        "List active approval flows with search and pagination. Returns paginated results with meta. Requires approval flows feature to be enabled.",
       inputSchema: {
-        search: z.string().optional().describe("Search term"),
-        page: z.number().int().positive().optional().describe("Page number"),
-        per_page: z.number().int().positive().optional().describe("Results per page"),
-        sort: z.string().optional().describe("Sort field"),
-        direction: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+        search: z.string().optional().describe("Search by flow name (case-insensitive)"),
+        page: z.number().int().positive().optional().describe("Page number (default: 1)"),
+        per_page: z.number().int().positive().optional().describe("Results per page (allowed: 10, 20, 50, 100)"),
+        sort: z.string().optional().describe("Sort column (e.g. 'id', 'name', 'created_at')"),
+        direction: z.enum(["asc", "desc"]).optional().describe("Sort direction (default: desc)"),
       },
     },
     withErrorHandling(async (args) => {
@@ -65,13 +70,14 @@ export function registerApprovalFlowTools(server: Server, apiClient: ApiClient):
   server.registerTool(
     "create_approval_flow",
     {
-      description: "Create an approval flow with steps, approvers, and conditions. document_type: 0=purchase_order, 1=invoice",
+      description:
+        "Create an approval flow with steps, approvers, and conditions. document_type: 0=purchase_order, 1=invoice. Flow-level conditions determine which documents match this flow. Step-level conditions determine which steps activate.",
       inputSchema: {
         name: z.string().describe("Flow name"),
         document_type: z.number().int().min(0).max(1).describe("0=purchase_order, 1=invoice"),
-        self_approval_allowed: z.boolean().optional().describe("Allow self-approval"),
-        steps: z.array(approvalStepSchema).describe("Approval steps with approvers"),
-        conditions: z.array(approvalConditionSchema).optional().describe("Flow-level conditions"),
+        self_approval_allowed: z.boolean().optional().describe("Allow PO creator to self-approve if they are an approver"),
+        steps: z.array(approvalStepSchema).describe("Approval steps with approvers (executed in step_no order)"),
+        conditions: z.array(approvalConditionSchema).optional().describe("Flow-level conditions (all must match for flow to apply)"),
       },
     },
     withErrorHandling(async (args) => {
@@ -81,6 +87,7 @@ export function registerApprovalFlowTools(server: Server, apiClient: ApiClient):
           document_type: args.document_type,
           self_approval_allowed: args.self_approval_allowed,
           approval_steps_attributes: args.steps.map((step) => ({
+            ...(step.id ? { id: step.id } : {}),
             step_no: step.step_no,
             all_should_approve: step.all_should_approve,
             approval_step_approvers_attributes: step.approver_user_ids.map((uid) => ({
@@ -101,9 +108,54 @@ export function registerApprovalFlowTools(server: Server, apiClient: ApiClient):
   );
 
   server.registerTool(
+    "update_approval_flow",
+    {
+      description:
+        "Update an existing approval flow. Include step/condition IDs to update existing items, omit ID for new items, use _destroy to remove.",
+      inputSchema: {
+        id: z.number().int().positive().describe("Approval Flow ID"),
+        name: z.string().optional().describe("Flow name"),
+        document_type: z.number().int().min(0).max(1).optional().describe("0=purchase_order, 1=invoice"),
+        self_approval_allowed: z.boolean().optional().describe("Allow self-approval"),
+        steps: z.array(approvalStepSchema).optional().describe("Approval steps"),
+        conditions: z.array(approvalConditionSchema).optional().describe("Flow-level conditions"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const { id, steps, conditions, ...flowData } = args;
+      const body: Record<string, unknown> = {
+        approval_flow: {
+          ...flowData,
+          ...(steps
+            ? {
+                approval_steps_attributes: steps.map((step) => ({
+                  ...(step.id ? { id: step.id } : {}),
+                  step_no: step.step_no,
+                  all_should_approve: step.all_should_approve,
+                  ...(step._destroy ? { _destroy: true } : {}),
+                  approval_step_approvers_attributes: step.approver_user_ids.map((uid) => ({
+                    user_id: uid,
+                  })),
+                  ...(step.conditions
+                    ? { approval_conditions_attributes: step.conditions }
+                    : {}),
+                })),
+              }
+            : {}),
+          ...(conditions
+            ? { approval_conditions_attributes: conditions }
+            : {}),
+        },
+      };
+      const flow = await apiClient.put<ApprovalFlow>(apiClient.buildPath(`/approval_flows/${id}`), body);
+      return jsonResponse(flow);
+    }),
+  );
+
+  server.registerTool(
     "delete_approval_flow",
     {
-      description: "Delete an approval flow",
+      description: "Delete an approval flow permanently",
       inputSchema: { id: z.number().int().positive().describe("Approval Flow ID") },
     },
     withErrorHandling(async (args) => {
@@ -115,7 +167,7 @@ export function registerApprovalFlowTools(server: Server, apiClient: ApiClient):
   server.registerTool(
     "archive_approval_flow",
     {
-      description: "Archive an approval flow",
+      description: "Archive an approval flow (soft delete — can be restored)",
       inputSchema: { id: z.number().int().positive().describe("Approval Flow ID") },
     },
     withErrorHandling(async (args) => {
@@ -125,17 +177,42 @@ export function registerApprovalFlowTools(server: Server, apiClient: ApiClient):
   );
 
   server.registerTool(
+    "publish_approval_flow",
+    {
+      description: "Publish an approval flow to make it active",
+      inputSchema: { id: z.number().int().positive().describe("Approval Flow ID") },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.patch(apiClient.buildPath(`/approval_flows/${args.id}/publish`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "unpublish_approval_flow",
+    {
+      description: "Unpublish an approval flow to deactivate it",
+      inputSchema: { id: z.number().int().positive().describe("Approval Flow ID") },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.patch(apiClient.buildPath(`/approval_flows/${args.id}/unpublish`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
     "list_approval_flow_runs",
     {
-      description: "List runs for an approval flow with status and date filters",
+      description: "List approval flow runs (entities that went through this flow) with status and date filters",
       inputSchema: {
         id: z.number().int().positive().describe("Approval Flow ID"),
-        status: z.enum(["in_progress", "completed", "rejected"]).optional().describe("Filter by status"),
+        status: z.enum(["in_progress", "completed", "rejected"]).optional().describe("Filter by run status"),
         keyword: z.string().optional().describe("Search keyword"),
-        date_range: z.enum(["24h", "7d", "30d", "60d", "custom"]).optional().describe("Date range filter"),
-        date_from: z.string().optional().describe("Start date (MM/DD/YYYY) for custom range"),
-        date_to: z.string().optional().describe("End date (MM/DD/YYYY) for custom range"),
+        date_range: z.enum(["24h", "7d", "30d", "60d", "custom"]).optional().describe("Predefined date range filter"),
+        date_from: z.string().optional().describe("Start date for custom range"),
+        date_to: z.string().optional().describe("End date for custom range"),
         page: z.number().int().positive().optional().describe("Page number"),
+        per_page: z.number().int().positive().optional().describe("Results per page"),
       },
     },
     withErrorHandling(async (args) => {

--- a/src/tools/approval-flows.ts
+++ b/src/tools/approval-flows.ts
@@ -7,7 +7,7 @@ import type { ApprovalFlow, PaginationMeta } from "../types.js";
 const approvalConditionSchema = z.object({
   id: z.number().int().optional().describe("Condition ID (for updates)"),
   property: z.string().describe("Condition property: budget, department, supplier, requester, gross_amount, net_amount, or custom_field_<id>"),
-  operator: z.string().describe("Operator: equals(0), not_equals(1), greater_than(2), less_than(3), contains(4), not_contains(5)"),
+  operator: z.enum(["equals", "not_equals", "greater_than", "less_than", "is_any_of", "is_none_of", "exists", "not_exists", "contains", "not_contains"]).describe("Condition operator"),
   value: z.string().describe("Condition value (single ID or comma-separated IDs for contains/not_contains)"),
   custom_field_id: z.number().int().optional().describe("Custom field ID (when property is custom_field_<id>)"),
   _destroy: z.boolean().optional().describe("Set true to remove this condition on update"),
@@ -224,6 +224,70 @@ export function registerApprovalFlowTools(server: Server, apiClient: ApiClient):
       const query = params.toString();
       const path = `${apiClient.buildPath(`/approval_flows/${id}/runs`)}${query ? `?${query}` : ""}`;
       const result = await apiClient.get(path);
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "get_approval_flow_entity",
+    {
+      description: "Get details about a specific entity (purchase order or invoice) that went through an approval flow",
+      inputSchema: {
+        id: z.number().int().positive().describe("Approval Flow ID"),
+        entity_id: z.number().int().positive().describe("Entity ID (purchase order or invoice ID)"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const path = `${apiClient.buildPath(`/approval_flows/${args.id}/show_entity`)}?entity_id=${args.entity_id}`;
+      const result = await apiClient.get(path);
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "list_approval_flow_versions",
+    {
+      description: "List all version history of an approval flow",
+      inputSchema: {
+        id: z.number().int().positive().describe("Approval Flow ID"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.get(apiClient.buildPath(`/approval_flows/${args.id}/versions`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "get_approval_flow_version_details",
+    {
+      description: "Get full details of a specific version of an approval flow",
+      inputSchema: {
+        id: z.number().int().positive().describe("Approval Flow ID"),
+        version_id: z.number().int().positive().describe("Version ID"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const path = `${apiClient.buildPath(`/approval_flows/${args.id}/version_details`)}?version_id=${args.version_id}`;
+      const result = await apiClient.get(path);
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "rerun_approval_flows",
+    {
+      description: "Rerun approval flows for specific purchase orders and/or invoices. Useful when approval flow rules have changed and need to be reapplied.",
+      inputSchema: {
+        order_ids: z.array(z.number().int()).optional().describe("Purchase order IDs to rerun approval flows for"),
+        invoice_ids: z.array(z.number().int()).optional().describe("Invoice IDs to rerun approval flows for"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const body: Record<string, unknown> = {};
+      if (args.order_ids) body.order_ids = args.order_ids;
+      if (args.invoice_ids) body.invoice_ids = args.invoice_ids;
+      const result = await apiClient.post(apiClient.buildPath("/approval_flows/rerun_approval_flows"), body);
       return jsonResponse(result);
     }),
   );

--- a/src/tools/budgets.ts
+++ b/src/tools/budgets.ts
@@ -2,29 +2,28 @@ import { z } from "zod";
 import type { ApiClient } from "../api-client.js";
 import type { Server } from "../tool-helpers.js";
 import { jsonResponse, withErrorHandling } from "../tool-helpers.js";
-import type { Budget, PaginationMeta } from "../types.js";
+import type { Budget } from "../types.js";
 
 export function registerBudgetTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_budgets",
     {
-      description: "List budgets with pagination. Filter by department, archived status, or active only",
+      description:
+        "List budgets for the current company. Filter by department and/or archived status. Returns all matching budgets (no pagination).",
       inputSchema: {
-        page: z.number().int().positive().optional().describe("Page number (default: 1)"),
-        archived: z.boolean().optional().describe("Filter by archived status"),
-        only_active: z.boolean().optional().describe("Show only active budgets"),
         department_id: z.number().int().optional().describe("Filter by department ID"),
+        archived: z.boolean().optional().describe("Filter by archived status (default: false)"),
+        show_mappings: z.boolean().optional().describe("Include third-party ID mappings in response"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
-      if (args.page) params.set("page", String(args.page));
-      if (args.archived !== undefined) params.set("archived", String(args.archived));
-      if (args.only_active) params.set("only_active", "true");
       if (args.department_id) params.set("department_id", String(args.department_id));
+      if (args.archived !== undefined) params.set("archived", String(args.archived));
+      if (args.show_mappings) params.set("show_mappings", "true");
       const query = params.toString();
       const path = `${apiClient.buildPath("/budgets")}${query ? `?${query}` : ""}`;
-      const result = await apiClient.get<{ budgets: Budget[]; meta: PaginationMeta }>(path);
+      const result = await apiClient.get<Budget[]>(path);
       return jsonResponse(result);
     }),
   );
@@ -32,7 +31,7 @@ export function registerBudgetTools(server: Server, apiClient: ApiClient): void 
   server.registerTool(
     "get_budget",
     {
-      description: "Get a specific budget by ID, including remaining amount",
+      description: "Get a specific budget by ID, including remaining amount and associated departments/approvers",
       inputSchema: {
         id: z.number().int().positive().describe("Budget ID"),
       },
@@ -46,19 +45,22 @@ export function registerBudgetTools(server: Server, apiClient: ApiClient): void 
   server.registerTool(
     "create_budget",
     {
-      description: "Create a new budget",
+      description:
+        "Create a new budget. Dates must match the company's date_format setting.",
       inputSchema: {
         name: z.string().describe("Budget name"),
         amount: z.number().describe("Budget amount"),
-        currency_id: z.number().int().describe("Currency ID"),
-        creator_id: z.number().int().describe("Creator user ID"),
+        currency_id: z.number().int().optional().describe("Currency ID (defaults to company currency)"),
+        creator_id: z.number().int().optional().describe("Creator user ID"),
         cost_code: z.string().optional().describe("Cost code"),
         cost_type: z.string().optional().describe("Cost type"),
-        start_date: z.string().optional().describe("Start date (must match company date format)"),
-        end_date: z.string().optional().describe("End date"),
-        allow_anyone_to_approve_a_po: z.boolean().optional().describe("Allow anyone to approve"),
+        start_date: z.string().optional().describe("Start date (must match company date_format setting)"),
+        end_date: z.string().optional().describe("End date (must match company date_format setting)"),
+        allow_anyone_to_approve_a_po: z.boolean().optional().describe("Allow anyone to approve POs against this budget"),
+        chart_of_account_id: z.number().int().optional().describe("Chart of account ID (GL code)"),
+        qbo_class: z.string().optional().describe("QuickBooks class"),
         approver_ids: z.array(z.number().int()).optional().describe("Approver user IDs"),
-        department_ids: z.array(z.number().int()).optional().describe("Department IDs"),
+        department_ids: z.array(z.number().int()).optional().describe("Department IDs to associate"),
       },
     },
     withErrorHandling(async (args) => {
@@ -75,10 +77,14 @@ export function registerBudgetTools(server: Server, apiClient: ApiClient): void 
         id: z.number().int().positive().describe("Budget ID"),
         name: z.string().optional().describe("Budget name"),
         amount: z.number().optional().describe("Budget amount"),
+        currency_id: z.number().int().optional().describe("Currency ID"),
         cost_code: z.string().optional().describe("Cost code"),
         cost_type: z.string().optional().describe("Cost type"),
-        start_date: z.string().optional().describe("Start date"),
-        end_date: z.string().optional().describe("End date"),
+        start_date: z.string().optional().describe("Start date (must match company date_format setting)"),
+        end_date: z.string().optional().describe("End date (must match company date_format setting)"),
+        allow_anyone_to_approve_a_po: z.boolean().optional().describe("Allow anyone to approve"),
+        chart_of_account_id: z.number().int().optional().describe("Chart of account ID"),
+        qbo_class: z.string().optional().describe("QuickBooks class"),
         approver_ids: z.array(z.number().int()).optional().describe("Approver user IDs"),
         department_ids: z.array(z.number().int()).optional().describe("Department IDs"),
       },

--- a/src/tools/budgets.ts
+++ b/src/tools/budgets.ts
@@ -4,6 +4,12 @@ import type { Server } from "../tool-helpers.js";
 import { jsonResponse, withErrorHandling } from "../tool-helpers.js";
 import type { Budget } from "../types.js";
 
+const customFieldValueSchema = z.object({
+  id: z.number().int().optional().describe("Custom field value ID (for updates)"),
+  value: z.string().describe("Custom field value"),
+  custom_field_id: z.number().int().describe("Custom field ID"),
+});
+
 export function registerBudgetTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_budgets",
@@ -61,6 +67,7 @@ export function registerBudgetTools(server: Server, apiClient: ApiClient): void 
         qbo_class: z.string().optional().describe("QuickBooks class"),
         approver_ids: z.array(z.number().int()).optional().describe("Approver user IDs"),
         department_ids: z.array(z.number().int()).optional().describe("Department IDs to associate"),
+        custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("Budget-level custom field values"),
       },
     },
     withErrorHandling(async (args) => {
@@ -87,6 +94,7 @@ export function registerBudgetTools(server: Server, apiClient: ApiClient): void 
         qbo_class: z.string().optional().describe("QuickBooks class"),
         approver_ids: z.array(z.number().int()).optional().describe("Approver user IDs"),
         department_ids: z.array(z.number().int()).optional().describe("Department IDs"),
+        custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("Budget-level custom field values"),
       },
     },
     withErrorHandling(async (args) => {

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -8,7 +8,7 @@ export function registerCommentTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "add_purchase_order_comment",
     {
-      description: "Add a comment to a purchase order",
+      description: "Add a comment to a purchase order. The comment creator is set to the authenticated user.",
       inputSchema: {
         purchase_order_id: z.number().int().positive().describe("Purchase Order ID"),
         comment: z.string().describe("Comment text"),
@@ -16,7 +16,7 @@ export function registerCommentTools(server: Server, apiClient: ApiClient): void
     },
     withErrorHandling(async (args) => {
       const result = await apiClient.post<PurchaseOrderComment>(
-        apiClient.buildPath(`/purchase_order/${args.purchase_order_id}/comments`),
+        apiClient.buildPath(`/purchase_orders/${args.purchase_order_id}/comments`),
         { comment: args.comment },
       );
       return jsonResponse(result);
@@ -26,7 +26,7 @@ export function registerCommentTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "add_invoice_comment",
     {
-      description: "Add a comment to an invoice",
+      description: "Add a comment to an invoice. The comment creator is set to the authenticated user.",
       inputSchema: {
         invoice_id: z.number().int().positive().describe("Invoice ID"),
         comment: z.string().describe("Comment text"),
@@ -35,7 +35,7 @@ export function registerCommentTools(server: Server, apiClient: ApiClient): void
     withErrorHandling(async (args) => {
       const result = await apiClient.post(
         apiClient.buildPath(`/invoices/${args.invoice_id}/create_comment`),
-        { comment: args.comment },
+        { invoice_comments: { comment: args.comment } },
       );
       return jsonResponse(result);
     }),

--- a/src/tools/companies.ts
+++ b/src/tools/companies.ts
@@ -20,13 +20,25 @@ export function registerCompanyTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "get_company",
     {
-      description: "Get company details including settings, custom fields, and supported currencies",
+      description: "Get company details by ID including settings, custom fields, and supported currencies",
       inputSchema: {
         id: z.number().int().positive().describe("Company ID"),
       },
     },
     withErrorHandling(async (args) => {
       const company = await apiClient.get<CompanyDetail>(apiClient.buildPath(`/companies/${args.id}`));
+      return jsonResponse(company);
+    }),
+  );
+
+  server.registerTool(
+    "get_company_details",
+    {
+      description: "Get details for the currently active company (set via set_active_company or PROCUREMENTEXPRESS_COMPANY_ID)",
+      inputSchema: {},
+    },
+    withErrorHandling(async () => {
+      const company = await apiClient.get<CompanyDetail>(apiClient.buildPath("/companies/details"));
       return jsonResponse(company);
     }),
   );
@@ -48,15 +60,18 @@ export function registerCompanyTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "list_approvers",
     {
-      description: "List approvers filtered by department (respects auto-approval settings)",
+      description:
+        "List approvers for the current company. Optionally filter by department. Returns empty if company uses approval flows or has no unassigned budgets.",
       inputSchema: {
-        department_id: z.number().int().positive().describe("Department ID to filter approvers"),
+        department_id: z.number().int().optional().describe("Filter approvers by department ID"),
       },
     },
     withErrorHandling(async (args) => {
-      const approvers = await apiClient.get<Approver[]>(
-        `${apiClient.buildPath("/companies/approvers")}?department_id=${args.department_id}`,
-      );
+      const params = new URLSearchParams();
+      if (args.department_id) params.set("department_id", String(args.department_id));
+      const query = params.toString();
+      const path = `${apiClient.buildPath("/companies/approvers")}${query ? `?${query}` : ""}`;
+      const approvers = await apiClient.get<Approver[]>(path);
       return jsonResponse(approvers);
     }),
   );
@@ -64,7 +79,7 @@ export function registerCompanyTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "list_all_approvers",
     {
-      description: "List all approvers regardless of auto-approval routing",
+      description: "List all approvers for the current company regardless of auto-approval routing",
       inputSchema: {},
     },
     withErrorHandling(async () => {
@@ -76,7 +91,7 @@ export function registerCompanyTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "list_employees",
     {
-      description: "List all employees of the current company with their roles",
+      description: "List all active employees of the current company with their roles (companyadmin role required)",
       inputSchema: {},
     },
     withErrorHandling(async () => {
@@ -89,18 +104,78 @@ export function registerCompanyTools(server: Server, apiClient: ApiClient): void
     "invite_user",
     {
       description:
-        "Invite a user to the company. Roles: companyadmin, approver, finance, teammember",
+        "Invite a user to the company. Roles: companyadmin, approver, finance, teammember. Requires available invite slots on the company plan.",
       inputSchema: {
         email: z.string().email().describe("Email address to invite"),
         name: z.string().describe("Name of the user"),
         roles: z
           .array(z.enum(["companyadmin", "approver", "finance", "teammember"]))
           .describe("Roles to assign"),
+        approval_limit: z.number().optional().describe("Approval limit amount (default: 0)"),
+        department_ids: z.array(z.number().int()).optional().describe("Department IDs to assign the user to"),
       },
     },
     withErrorHandling(async (args) => {
       const result = await apiClient.post(apiClient.buildPath("/companies/send_user_invite"), {
         invite_user: args,
+      });
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "get_invite_limit",
+    {
+      description: "Get the remaining invite slots for the current company",
+      inputSchema: {},
+    },
+    withErrorHandling(async () => {
+      const result = await apiClient.get<{ invite_limit_left: number; active_users: number; allowed_users: number }>(
+        apiClient.buildPath("/companies/invite_limit_left"),
+      );
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "list_pending_invites",
+    {
+      description: "List pending user invitations for the current company (companyadmin role required)",
+      inputSchema: {},
+    },
+    withErrorHandling(async () => {
+      const result = await apiClient.get(apiClient.buildPath("/companies/pending_invites"));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "cancel_invite",
+    {
+      description: "Cancel a pending user invitation (companyadmin role required)",
+      inputSchema: {
+        token: z.string().describe("Invite token from the pending invite"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.post(apiClient.buildPath("/companies/cancel_invite"), {
+        token: args.token,
+      });
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "resend_invite",
+    {
+      description: "Resend a pending user invitation email (companyadmin role required)",
+      inputSchema: {
+        token: z.string().describe("Invite token from the pending invite"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.post(apiClient.buildPath("/companies/resend_invite"), {
+        token: args.token,
       });
       return jsonResponse(result);
     }),

--- a/src/tools/departments.ts
+++ b/src/tools/departments.ts
@@ -8,10 +8,11 @@ export function registerDepartmentTools(server: Server, apiClient: ApiClient): v
   server.registerTool(
     "list_departments",
     {
-      description: "List departments with optional filters for archived status and company-specific",
+      description:
+        "List departments. By default returns only departments the current user has access to. Set company_specific=true to list all company departments regardless of user access.",
       inputSchema: {
-        archived: z.boolean().optional().describe("Filter by archived status"),
-        company_specific: z.boolean().optional().describe("Show only company-specific departments"),
+        archived: z.boolean().optional().describe("Filter by archived status (default: false)"),
+        company_specific: z.boolean().optional().describe("True to list all company departments, false/omit for user's departments only"),
       },
     },
     withErrorHandling(async (args) => {
@@ -45,9 +46,9 @@ export function registerDepartmentTools(server: Server, apiClient: ApiClient): v
       description: "Create a new department",
       inputSchema: {
         name: z.string().describe("Department name"),
-        contact_person: z.string().optional().describe("Contact person"),
+        contact_person: z.string().optional().describe("Contact person name"),
         phone_number: z.string().optional().describe("Phone number"),
-        email: z.string().email().optional().describe("Email"),
+        email: z.string().optional().describe("Email address"),
         address: z.string().optional().describe("Address"),
         tax_number: z.string().optional().describe("Tax number"),
         budget_ids: z.array(z.number().int()).optional().describe("Budget IDs to associate"),
@@ -72,7 +73,7 @@ export function registerDepartmentTools(server: Server, apiClient: ApiClient): v
         archived: z.boolean().optional().describe("Archive status"),
         contact_person: z.string().optional().describe("Contact person"),
         phone_number: z.string().optional().describe("Phone number"),
-        email: z.string().email().optional().describe("Email"),
+        email: z.string().optional().describe("Email"),
         address: z.string().optional().describe("Address"),
         tax_number: z.string().optional().describe("Tax number"),
         budget_ids: z.array(z.number().int()).optional().describe("Budget IDs"),

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -4,6 +4,12 @@ import type { Server } from "../tool-helpers.js";
 import { jsonResponse, withErrorHandling } from "../tool-helpers.js";
 import type { Invoice, PaginationMeta } from "../types.js";
 
+const customFieldValueSchema = z.object({
+  id: z.number().int().optional().describe("Custom field value ID (for updates)"),
+  value: z.string().describe("Custom field value"),
+  custom_field_id: z.number().int().describe("Custom field ID"),
+});
+
 const invoiceLineItemSchema = z.object({
   id: z.number().int().optional().describe("Line item ID (for updates)"),
   description: z.string().optional().describe("Line item description"),
@@ -21,6 +27,7 @@ const invoiceLineItemSchema = z.object({
   purchase_order_item_id: z.number().int().optional().describe("Related PO line item ID"),
   billable_status: z.string().optional().describe("Billable status for QuickBooks"),
   _destroy: z.boolean().optional().describe("Set true to remove this line item on update"),
+  custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("Custom field values for this line item"),
 });
 
 export function registerInvoiceTools(server: Server, apiClient: ApiClient): void {
@@ -42,7 +49,10 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
         requester_id: z.number().int().optional().describe("Filter by requester/creator user ID"),
         approver_id: z.number().int().optional().describe("Filter by approver user ID"),
         department_id: z.number().int().optional().describe("Filter by department ID (via linked POs)"),
-        invoice_date_filter: z.string().optional().describe("Date filter (e.g. 'last 7days', 'last 30days', 'current_month', 'last_month')"),
+        invoice_date_filter: z
+          .enum(["last 7days", "last 30days", "last 60days", "last 90days", "last 180days", "last 1year", "current_month", "current_year", "last_month", "last_year"])
+          .optional()
+          .describe("Predefined date range filter"),
         sage_exported: z.boolean().optional().describe("Filter by Sage export status"),
         sort: z.string().optional().describe("Sort column (e.g. 'invoices.created_at', 'invoices.issue_date')"),
         direction: z.enum(["asc", "desc"]).optional().describe("Sort direction (default: desc)"),
@@ -102,14 +112,16 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
         payment_term_id: z.number().int().optional().describe("Payment term ID"),
         selected_purchase_order_ids: z.array(z.number().int()).optional().describe("PO IDs to link this invoice to"),
         line_items: z.array(invoiceLineItemSchema).optional().describe("Invoice line items"),
+        custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("Invoice-level custom field values"),
       },
     },
     withErrorHandling(async (args) => {
-      const { line_items, ...invoiceData } = args;
+      const { line_items, custom_field_values_attributes, ...invoiceData } = args;
       const body: Record<string, unknown> = {
         invoice: {
           ...invoiceData,
           ...(line_items ? { invoice_line_items_attributes: line_items } : {}),
+          ...(custom_field_values_attributes ? { custom_field_values_attributes } : {}),
         },
       };
       const invoice = await apiClient.post<Invoice>(apiClient.buildPath("/invoices"), body);
@@ -135,14 +147,16 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
         payment_term_id: z.number().int().optional().describe("Payment term ID"),
         selected_purchase_order_ids: z.array(z.number().int()).optional().describe("PO IDs to link"),
         line_items: z.array(invoiceLineItemSchema).optional().describe("Invoice line items (include id to update, _destroy to remove)"),
+        custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("Invoice-level custom field values"),
       },
     },
     withErrorHandling(async (args) => {
-      const { id, line_items, ...data } = args;
+      const { id, line_items, custom_field_values_attributes, ...data } = args;
       const body: Record<string, unknown> = {
         invoice: {
           ...data,
           ...(line_items ? { invoice_line_items_attributes: line_items } : {}),
+          ...(custom_field_values_attributes ? { custom_field_values_attributes } : {}),
         },
       };
       const invoice = await apiClient.put<Invoice>(apiClient.buildPath(`/invoices/${id}`), body);

--- a/src/tools/invoices.ts
+++ b/src/tools/invoices.ts
@@ -5,37 +5,64 @@ import { jsonResponse, withErrorHandling } from "../tool-helpers.js";
 import type { Invoice, PaginationMeta } from "../types.js";
 
 const invoiceLineItemSchema = z.object({
-  description: z.string().describe("Line item description"),
-  unit_price: z.number().describe("Unit price"),
-  quantity: z.number().describe("Quantity"),
-  vat: z.number().optional().describe("VAT amount"),
+  id: z.number().int().optional().describe("Line item ID (for updates)"),
+  description: z.string().optional().describe("Line item description"),
+  unit_price: z.number().optional().describe("Unit price"),
+  quantity: z.number().optional().describe("Quantity"),
+  vat: z.number().optional().describe("VAT/tax percentage"),
   net_amount: z.number().optional().describe("Net amount"),
-  purchase_order_id: z.number().int().optional().describe("Related PO ID"),
-  purchase_order_item_id: z.number().int().optional().describe("Related PO item ID"),
+  sequence_no: z.number().int().optional().describe("Sequence number for ordering"),
+  tax_rate_id: z.number().int().optional().describe("Tax rate ID"),
+  chart_of_account_id: z.number().int().optional().describe("Chart of account ID (GL code)"),
+  qbo_customer_id: z.number().int().optional().describe("QuickBooks customer ID"),
+  quickbooks_class_id: z.number().int().optional().describe("QuickBooks class ID"),
+  qbo_line_description: z.string().optional().describe("QuickBooks line description override"),
+  purchase_order_id: z.number().int().optional().describe("Related purchase order ID"),
+  purchase_order_item_id: z.number().int().optional().describe("Related PO line item ID"),
+  billable_status: z.string().optional().describe("Billable status for QuickBooks"),
+  _destroy: z.boolean().optional().describe("Set true to remove this line item on update"),
 });
 
 export function registerInvoiceTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_invoices",
     {
-      description: "List invoices with pagination and filters (100 per page)",
+      description:
+        "List invoices with pagination and filters. Returns paginated results with meta info (current_page, next_page, prev_page, total_pages, total_count). Per-page count is controlled by company settings (default 10, allowed: 10, 20, 50, 100).",
       inputSchema: {
-        page: z.number().int().positive().optional().describe("Page number"),
-        archived: z.boolean().optional().describe("Filter by archived status"),
-        requester_id: z.number().int().optional().describe("Filter by requester ID"),
-        approver_id: z.number().int().optional().describe("Filter by approver ID"),
+        page: z.number().int().positive().optional().describe("Page number (default: 1)"),
+        per_page: z.number().int().optional().describe("Results per page (allowed: 10, 20, 50, 100)"),
+        search: z.string().optional().describe("Search term — matches invoice number, supplier name"),
+        invoice_statuses_filter: z
+          .enum(["awaiting_review", "outstanding", "ready_to_pay", "settled", "cancelled"])
+          .optional()
+          .describe("Filter by invoice status"),
+        archived: z.boolean().optional().describe("Filter by archived status (default: false)"),
         supplier_id: z.number().int().optional().describe("Filter by supplier ID"),
-        invoice_date_filter: z.string().optional().describe("Date filter (e.g. 'last 7days')"),
+        requester_id: z.number().int().optional().describe("Filter by requester/creator user ID"),
+        approver_id: z.number().int().optional().describe("Filter by approver user ID"),
+        department_id: z.number().int().optional().describe("Filter by department ID (via linked POs)"),
+        invoice_date_filter: z.string().optional().describe("Date filter (e.g. 'last 7days', 'last 30days', 'current_month', 'last_month')"),
+        sage_exported: z.boolean().optional().describe("Filter by Sage export status"),
+        sort: z.string().optional().describe("Sort column (e.g. 'invoices.created_at', 'invoices.issue_date')"),
+        direction: z.enum(["asc", "desc"]).optional().describe("Sort direction (default: desc)"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
       if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
+      if (args.search) params.set("search[query]", args.search);
+      if (args.invoice_statuses_filter) params.set("invoice_statuses_filter", args.invoice_statuses_filter);
       if (args.archived !== undefined) params.set("archived", String(args.archived));
+      if (args.supplier_id) params.set("supplier_id", String(args.supplier_id));
       if (args.requester_id) params.set("requester_id", String(args.requester_id));
       if (args.approver_id) params.set("approver_id", String(args.approver_id));
-      if (args.supplier_id) params.set("supplier_id", String(args.supplier_id));
+      if (args.department_id) params.set("department_id", String(args.department_id));
       if (args.invoice_date_filter) params.set("invoice_date_filter", args.invoice_date_filter);
+      if (args.sage_exported !== undefined) params.set("sage_exported", String(args.sage_exported));
+      if (args.sort) params.set("sort", args.sort);
+      if (args.direction) params.set("direction", args.direction);
       const query = params.toString();
       const path = `${apiClient.buildPath("/invoices")}${query ? `?${query}` : ""}`;
       const result = await apiClient.get<{ invoices: Invoice[]; meta: PaginationMeta }>(path);
@@ -46,7 +73,7 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "get_invoice",
     {
-      description: "Get invoice details by ID",
+      description: "Get invoice details by ID, including line items, linked POs, and comments",
       inputSchema: {
         id: z.number().int().positive().describe("Invoice ID"),
       },
@@ -60,16 +87,20 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "create_invoice",
     {
-      description: "Create a new invoice",
+      description:
+        "Create a new invoice. If the company has 'create invoice in awaiting review' enabled, the invoice starts in awaiting_review status.",
       inputSchema: {
-        invoice_number: z.string().optional().describe("Invoice number"),
-        issue_date: z.string().optional().describe("Issue date"),
-        supplier_id: z.number().int().optional().describe("Supplier ID"),
+        invoice_number: z.string().optional().describe("Invoice number/reference"),
+        issue_date: z.string().optional().describe("Issue date (format depends on company date_format)"),
+        uploaded_date: z.string().optional().describe("Upload date"),
         received_date: z.string().optional().describe("Received date"),
         due_date: z.string().optional().describe("Due date"),
-        gross_amount: z.number().describe("Gross amount"),
-        currency_id: z.number().int().describe("Currency ID"),
-        company_id: z.number().int().describe("Company ID"),
+        gross_amount: z.number().optional().describe("Gross amount"),
+        currency_id: z.number().int().optional().describe("Currency ID"),
+        supplier_id: z.number().int().optional().describe("Supplier ID"),
+        standalone_invoice: z.boolean().optional().describe("True if invoice is not linked to any PO"),
+        payment_term_id: z.number().int().optional().describe("Payment term ID"),
+        selected_purchase_order_ids: z.array(z.number().int()).optional().describe("PO IDs to link this invoice to"),
         line_items: z.array(invoiceLineItemSchema).optional().describe("Invoice line items"),
       },
     },
@@ -94,14 +125,27 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
         id: z.number().int().positive().describe("Invoice ID"),
         invoice_number: z.string().optional().describe("Invoice number"),
         issue_date: z.string().optional().describe("Issue date"),
-        supplier_id: z.number().int().optional().describe("Supplier ID"),
+        uploaded_date: z.string().optional().describe("Upload date"),
+        received_date: z.string().optional().describe("Received date"),
         due_date: z.string().optional().describe("Due date"),
         gross_amount: z.number().optional().describe("Gross amount"),
+        currency_id: z.number().int().optional().describe("Currency ID"),
+        supplier_id: z.number().int().optional().describe("Supplier ID"),
+        standalone_invoice: z.boolean().optional().describe("Standalone invoice flag"),
+        payment_term_id: z.number().int().optional().describe("Payment term ID"),
+        selected_purchase_order_ids: z.array(z.number().int()).optional().describe("PO IDs to link"),
+        line_items: z.array(invoiceLineItemSchema).optional().describe("Invoice line items (include id to update, _destroy to remove)"),
       },
     },
     withErrorHandling(async (args) => {
-      const { id, ...data } = args;
-      const invoice = await apiClient.put<Invoice>(apiClient.buildPath(`/invoices/${id}`), { invoice: data });
+      const { id, line_items, ...data } = args;
+      const body: Record<string, unknown> = {
+        invoice: {
+          ...data,
+          ...(line_items ? { invoice_line_items_attributes: line_items } : {}),
+        },
+      };
+      const invoice = await apiClient.put<Invoice>(apiClient.buildPath(`/invoices/${id}`), body);
       return jsonResponse(invoice);
     }),
   );
@@ -109,7 +153,7 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "accept_invoice",
     {
-      description: "Accept an invoice that is awaiting review",
+      description: "Accept an invoice that is in awaiting_review status",
       inputSchema: { id: z.number().int().positive().describe("Invoice ID") },
     },
     withErrorHandling(async (args) => {
@@ -121,7 +165,7 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "approve_invoice",
     {
-      description: "Approve an invoice",
+      description: "Approve an invoice (requires invoice approval permission)",
       inputSchema: { id: z.number().int().positive().describe("Invoice ID") },
     },
     withErrorHandling(async (args) => {
@@ -133,7 +177,7 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "reject_invoice",
     {
-      description: "Reject an invoice",
+      description: "Reject an invoice (requires invoice approval permission)",
       inputSchema: { id: z.number().int().positive().describe("Invoice ID") },
     },
     withErrorHandling(async (args) => {
@@ -145,7 +189,7 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "cancel_invoice",
     {
-      description: "Cancel an invoice",
+      description: "Cancel an invoice (requires cancel permission)",
       inputSchema: { id: z.number().int().positive().describe("Invoice ID") },
     },
     withErrorHandling(async (args) => {
@@ -157,7 +201,7 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "archive_invoice",
     {
-      description: "Archive an invoice",
+      description: "Archive an invoice (requires archive permission)",
       inputSchema: { id: z.number().int().positive().describe("Invoice ID") },
     },
     withErrorHandling(async (args) => {
@@ -174,6 +218,18 @@ export function registerInvoiceTools(server: Server, apiClient: ApiClient): void
     },
     withErrorHandling(async (args) => {
       const result = await apiClient.put(apiClient.buildPath(`/invoices/${args.id}/dearchive`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "rerun_invoice_approval_flow",
+    {
+      description: "Rerun the approval flow for an invoice. Useful when approval flow rules have changed.",
+      inputSchema: { id: z.number().int().positive().describe("Invoice ID") },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.post(apiClient.buildPath(`/invoices/${args.id}/rerun_approval_flow`));
       return jsonResponse(result);
     }),
   );

--- a/src/tools/payments.ts
+++ b/src/tools/payments.ts
@@ -6,13 +6,26 @@ import type { Payment } from "../types.js";
 
 export function registerPaymentTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
+    "get_payment",
+    {
+      description: "Get payment details by ID",
+      inputSchema: {
+        id: z.number().int().positive().describe("Payment ID"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const payment = await apiClient.get<Payment>(apiClient.buildPath(`/npayments/${args.id}`));
+      return jsonResponse(payment);
+    }),
+  );
+
+  server.registerTool(
     "create_payment",
     {
       description:
-        "Create a payment (feature flagged). ptype values: bank_transfer, card, credit_card, check, cash, one_time_card, letter_of_credit, other",
+        "Create a payment to settle invoices and/or purchase orders (feature flagged — contact sales to enable). The payment date must match the company's date_format setting.",
       inputSchema: {
-        user_id: z.number().int().describe("Payment creator user ID"),
-        reference: z.string().optional().describe("Reference number"),
+        reference: z.string().optional().describe("Payment reference number"),
         supplier_id: z.number().int().describe("Supplier ID"),
         ptype: z
           .enum([
@@ -26,25 +39,48 @@ export function registerPaymentTools(server: Server, apiClient: ApiClient): void
             "other",
           ])
           .describe("Payment type"),
-        date: z.string().describe("Payment date"),
+        payment_mode: z.string().optional().describe("Payment mode"),
+        status: z.string().optional().describe("Payment status"),
+        date: z.string().describe("Payment date (must match company date_format setting)"),
         currency_id: z.number().int().describe("Currency ID"),
-        amount: z.number().describe("Total amount (must match sum of invoice amounts)"),
+        amount: z.number().describe("Total payment amount"),
         invoices: z
           .array(
             z.object({
               invoice_id: z.number().int().describe("Invoice ID"),
-              gross_amount: z.number().describe("Amount for this invoice"),
+              gross_amount: z.number().describe("Amount to apply to this invoice"),
             }),
           )
-          .describe("Invoices to pay"),
+          .optional()
+          .describe("Invoices to pay with amounts"),
+        purchase_orders: z
+          .array(
+            z.object({
+              purchase_order_id: z.number().int().describe("Purchase Order ID"),
+              budget_id: z.number().int().optional().describe("Budget ID"),
+              gross_amount: z.number().describe("Amount to apply to this PO"),
+            }),
+          )
+          .optional()
+          .describe("Purchase orders to pay with amounts"),
+        comments: z
+          .array(
+            z.object({
+              comment: z.string().describe("Comment text"),
+            }),
+          )
+          .optional()
+          .describe("Payment comments"),
       },
     },
     withErrorHandling(async (args) => {
-      const { invoices, ...paymentData } = args;
-      const body = {
+      const { invoices, purchase_orders, comments, ...paymentData } = args;
+      const body: Record<string, unknown> = {
         npayment: {
           ...paymentData,
-          npayment_invoices_attributes: invoices,
+          ...(invoices ? { npayment_invoices_attributes: invoices } : {}),
+          ...(purchase_orders ? { npayment_link_orders_attributes: purchase_orders } : {}),
+          ...(comments ? { npayment_comments_attributes: comments } : {}),
         },
       };
       const payment = await apiClient.post<Payment>(apiClient.buildPath("/npayments"), body);
@@ -55,25 +91,31 @@ export function registerPaymentTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "create_po_payment",
     {
-      description: "Create a payment for a purchase order",
+      description:
+        "Create a payment for a specific purchase order with optional item-level breakdown. Marks PO items as paid.",
       inputSchema: {
         purchase_order_id: z.number().int().positive().describe("Purchase Order ID"),
+        amount: z.number().optional().describe("Total payment amount (if not using item-level payments)"),
         note: z.string().optional().describe("Payment note"),
         item_payments: z
           .array(
             z.object({
-              purchase_order_item_id: z.number().int().describe("PO item ID"),
+              purchase_order_item_id: z.number().int().describe("PO line item ID"),
               amount: z.number().describe("Payment amount for this item"),
             }),
           )
+          .optional()
           .describe("Item-level payment amounts"),
       },
     },
     withErrorHandling(async (args) => {
-      const body = {
+      const body: Record<string, unknown> = {
         payment: {
-          note: args.note,
-          purchase_order_item_payments_attributes: args.item_payments,
+          ...(args.amount !== undefined ? { amount: args.amount } : {}),
+          ...(args.note ? { note: args.note } : {}),
+          ...(args.item_payments
+            ? { purchase_order_item_payments_attributes: args.item_payments }
+            : {}),
         },
       };
       const result = await apiClient.post(

--- a/src/tools/products.ts
+++ b/src/tools/products.ts
@@ -2,25 +2,30 @@ import { z } from "zod";
 import type { ApiClient } from "../api-client.js";
 import type { Server } from "../tool-helpers.js";
 import { jsonResponse, withErrorHandling } from "../tool-helpers.js";
-import type { Product } from "../types.js";
+import type { PaginationMeta, Product } from "../types.js";
 
 export function registerProductTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_products",
     {
-      description: "List products with optional filters for supplier and archived status",
+      description:
+        "List products. When page param is provided, returns paginated response with meta. Without page param, returns all products as an array. Can filter by supplier and archived status.",
       inputSchema: {
+        page: z.number().int().positive().optional().describe("Page number — enables pagination"),
+        per_page: z.number().int().positive().optional().describe("Results per page (default: 20)"),
         supplier_id: z.number().int().optional().describe("Filter by supplier ID"),
-        archived: z.boolean().optional().describe("Filter by archived status"),
+        archived: z.boolean().optional().describe("Filter by archived status (default: false)"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
       if (args.supplier_id) params.set("supplier_id", String(args.supplier_id));
       if (args.archived !== undefined) params.set("archived", String(args.archived));
       const query = params.toString();
       const path = `${apiClient.buildPath("/products")}${query ? `?${query}` : ""}`;
-      const products = await apiClient.get<Product[]>(path);
+      const products = await apiClient.get<Product[] | { products: Product[]; meta: PaginationMeta }>(path);
       return jsonResponse(products);
     }),
   );
@@ -42,12 +47,12 @@ export function registerProductTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "create_product",
     {
-      description: "Create a new product",
+      description: "Create a new product and associate it with a supplier",
       inputSchema: {
         description: z.string().describe("Product description (required)"),
+        supplier_id: z.number().int().describe("Supplier ID (required — product is associated with this supplier)"),
         sku: z.string().optional().describe("SKU code"),
         unit_price: z.number().optional().describe("Unit price"),
-        supplier_id: z.number().int().optional().describe("Supplier ID"),
       },
     },
     withErrorHandling(async (args) => {
@@ -66,7 +71,6 @@ export function registerProductTools(server: Server, apiClient: ApiClient): void
         sku: z.string().optional().describe("SKU code"),
         unit_price: z.number().optional().describe("Unit price"),
         supplier_id: z.number().int().optional().describe("Supplier ID"),
-        archived: z.boolean().optional().describe("Archive status"),
       },
     },
     withErrorHandling(async (args) => {

--- a/src/tools/purchase-orders.ts
+++ b/src/tools/purchase-orders.ts
@@ -5,11 +5,13 @@ import { jsonResponse, textResponse, withErrorHandling } from "../tool-helpers.j
 import type { PaginationMeta, PurchaseOrder } from "../types.js";
 
 const customFieldValueSchema = z.object({
-  custom_field_id: z.number().int().describe("Custom field ID"),
+  id: z.number().int().optional().describe("Custom field value ID (for updates)"),
   value: z.string().describe("Custom field value"),
+  custom_field_id: z.number().int().describe("Custom field ID"),
 });
 
 const lineItemSchema = z.object({
+  id: z.number().int().optional().describe("Line item ID (for updates)"),
   description: z.string().describe("Item description"),
   quantity: z.number().describe("Quantity"),
   unit_price: z.number().describe("Unit price"),
@@ -172,16 +174,18 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
         submitted_on: z.string().optional().describe("Submission date"),
         line_items: z.array(lineItemSchema).optional().describe("Line items (include id to update existing, _destroy to remove)"),
         approver_list: z.array(z.number().int()).optional().describe("Approver user IDs"),
+        custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("PO-level custom field values"),
       },
     },
     withErrorHandling(async (args) => {
-      const { id, commit, line_items, approver_list, ...poData } = args;
+      const { id, commit, line_items, approver_list, custom_field_values_attributes, ...poData } = args;
       const body: Record<string, unknown> = {
         ...(commit ? { commit } : {}),
         purchase_order: {
           ...poData,
           ...(line_items ? { purchase_order_items_attributes: line_items } : {}),
           ...(approver_list ? { approver_list } : {}),
+          ...(custom_field_values_attributes ? { custom_field_values_attributes } : {}),
         },
       };
       const po = await apiClient.put<PurchaseOrder>(apiClient.buildPath(`/purchase_orders/${id}`), body);

--- a/src/tools/purchase-orders.ts
+++ b/src/tools/purchase-orders.ts
@@ -14,33 +14,82 @@ const lineItemSchema = z.object({
   quantity: z.number().describe("Quantity"),
   unit_price: z.number().describe("Unit price"),
   budget_id: z.number().int().optional().describe("Budget ID"),
-  vat: z.number().optional().describe("VAT amount"),
-  item_number: z.string().optional().describe("Item number"),
-  sequence_no: z.number().int().optional().describe("Sequence number"),
+  vat: z.number().optional().describe("VAT/tax percentage"),
   tax_rate_id: z.number().int().optional().describe("Tax rate ID"),
-  custom_field_values: z.array(customFieldValueSchema).optional().describe("Custom field values for this line item (for fields where on_line_item is true)"),
+  item_number: z.string().optional().describe("Item number"),
+  sequence_no: z.number().int().optional().describe("Sequence number for ordering"),
+  department_id: z.number().int().optional().describe("Department ID for the line item"),
+  product_id: z.number().int().optional().describe("Product ID"),
+  chart_of_account_id: z.number().int().optional().describe("Chart of account ID (GL code)"),
+  qbo_customer_id: z.number().int().optional().describe("QuickBooks customer ID"),
+  quickbooks_class_id: z.number().int().optional().describe("QuickBooks class ID"),
+  qbo_line_description: z.string().optional().describe("QuickBooks line description override"),
+  archived: z.boolean().optional().describe("Whether the line item is archived"),
+  _destroy: z.boolean().optional().describe("Set true to remove this line item on update"),
+  custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("Custom field values for this line item"),
 });
 
 export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_purchase_orders",
     {
-      description: "List purchase orders with pagination and search",
+      description:
+        "List purchase orders with pagination, search, and filters. Returns paginated results with meta info (current_page, next_page, prev_page, total_pages, total_count).",
       inputSchema: {
-        orders_page: z.number().int().positive().optional().describe("Page number (default: 1)"),
-        search: z.string().optional().describe("Search term"),
-        requests: z.boolean().optional().describe("Set to true to list pending approval requests"),
-        sort: z.string().optional().describe("Sort field"),
-        direction: z.enum(["asc", "desc"]).optional().describe("Sort direction"),
+        page: z.number().int().positive().optional().describe("Page number (default: 1). Use 'orders_page' as alias."),
+        search: z.string().optional().describe("Search term — matches PO number, supplier name, notes, line item descriptions"),
+        status: z
+          .enum(["draft", "pending", "approved", "rejected", "cancelled", "paid"])
+          .optional()
+          .describe("Filter by PO status"),
+        delivery_status: z
+          .enum(["not_delivered", "partially_delivered", "complete_delivered"])
+          .optional()
+          .describe("Filter by delivery status"),
+        payment_status: z
+          .enum(["unpaid", "partially_paid", "paid", "invoice_received"])
+          .optional()
+          .describe("Filter by payment status"),
+        supplier_id: z.number().int().optional().describe("Filter by supplier ID"),
+        requester_id: z.number().int().optional().describe("Filter by creator/requester user ID"),
+        budget_id: z.number().int().optional().describe("Filter by budget ID"),
+        filter_dept_id: z.number().int().optional().describe("Filter by department ID"),
+        approver_id: z.number().int().optional().describe("Filter by approver user ID"),
+        archived: z.boolean().optional().describe("Filter archived POs (default: false)"),
+        date_filter: z
+          .enum(["current_month", "current_year", "last_month", "last_year"])
+          .optional()
+          .describe("Predefined date range filter"),
+        from: z.string().optional().describe("Custom date range start (format depends on company date_format setting)"),
+        to: z.string().optional().describe("Custom date range end"),
+        updated_after: z.string().optional().describe("ISO datetime — only return POs updated after this timestamp (includes line item and custom field changes)"),
+        sort: z.string().optional().describe("Sort column (e.g. 'submitted_on', 'total_gross_amount', 'suppliers.name')"),
+        direction: z.enum(["asc", "desc"]).optional().describe("Sort direction (default: desc)"),
+        requests: z.boolean().optional().describe("Set true to include pending approval requests"),
+        bell: z.boolean().optional().describe("Set true with requests=true to show only bell notification items"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
-      if (args.orders_page) params.set("orders_page", String(args.orders_page));
+      if (args.page) params.set("orders_page", String(args.page));
       if (args.search) params.set("search", args.search);
-      if (args.requests) params.set("requests", "true");
+      if (args.status) params.set("status", args.status);
+      if (args.delivery_status) params.set("delivery_status", args.delivery_status);
+      if (args.payment_status) params.set("payment_status", args.payment_status);
+      if (args.supplier_id) params.set("supplier_id", String(args.supplier_id));
+      if (args.requester_id) params.set("requester_id", String(args.requester_id));
+      if (args.budget_id) params.set("budget_id", String(args.budget_id));
+      if (args.filter_dept_id) params.set("filter_dept_id", String(args.filter_dept_id));
+      if (args.approver_id) params.set("approver_id", String(args.approver_id));
+      if (args.archived !== undefined) params.set("archived", String(args.archived));
+      if (args.date_filter) params.set("date_filter", args.date_filter);
+      if (args.from) params.set("from", args.from);
+      if (args.to) params.set("to", args.to);
+      if (args.updated_after) params.set("updated_after", args.updated_after);
       if (args.sort) params.set("sort", args.sort);
       if (args.direction) params.set("direction", args.direction);
+      if (args.requests) params.set("requests", "true");
+      if (args.bell) params.set("bell", "true");
       const query = params.toString();
       const path = `${apiClient.buildPath("/purchase_orders")}${query ? `?${query}` : ""}`;
       const result = await apiClient.get<{
@@ -54,9 +103,10 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "get_purchase_order",
     {
-      description: "Get purchase order details including line items, comments, approvals, and status flags",
+      description:
+        "Get purchase order details including line items, comments, approvals, and status flags. The ID parameter accepts a numeric ID, approval-key, or slug.",
       inputSchema: {
-        id: z.number().int().positive().describe("Purchase Order ID"),
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
       },
     },
     withErrorHandling(async (args) => {
@@ -68,39 +118,73 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "create_purchase_order",
     {
-      description: "Create a new purchase order. Use commit='Send' to submit or 'Draft' to save as draft",
+      description:
+        "Create a new purchase order. Use commit='Send' to submit for approval or 'Draft' to save as draft. At least one line item is required.",
       inputSchema: {
         commit: z.enum(["Send", "Draft"]).describe("'Send' to submit for approval, 'Draft' to save as draft"),
         department_id: z.number().int().optional().describe("Department ID"),
         creator_id: z.number().int().describe("Creator user ID"),
-        supplier_id: z.number().int().optional().describe("Supplier ID"),
-        supplier_name: z.string().optional().describe("Supplier name (for new suppliers)"),
-        currency_id: z.number().int().describe("Currency ID"),
-        notes: z.string().optional().describe("PO notes"),
+        supplier_id: z.number().int().optional().describe("Existing supplier ID"),
+        supplier_name: z.string().optional().describe("Supplier name (used when supplier_id is not provided)"),
+        new_supplier_name: z.string().optional().describe("Create a new supplier with this name"),
+        currency_id: z.number().int().optional().describe("Currency ID (defaults to company/user currency)"),
+        iso_code: z.string().optional().describe("Currency ISO code (e.g. 'USD') — alternative to currency_id"),
+        notes: z.string().optional().describe("PO notes/description"),
+        submitted_on: z.string().optional().describe("Submission date (format depends on company date_format)"),
+        on_behalf_of: z.number().int().optional().describe("Create PO on behalf of this user ID (companyadmin only, user must be active employee)"),
         line_items: z.array(lineItemSchema).min(1).describe("Line items (at least one required)"),
-        approver_list: z.array(z.number().int()).optional().describe("Approver IDs"),
-        custom_field_values: z.array(customFieldValueSchema).optional().describe("PO-level custom field values (for fields where on_line_item is false). Use get_company to discover available custom fields."),
+        approver_list: z.array(z.number().int()).optional().describe("Approver user IDs"),
+        custom_field_values_attributes: z.array(customFieldValueSchema).optional().describe("PO-level custom field values"),
       },
     },
     withErrorHandling(async (args) => {
-      const { commit, line_items, approver_list, custom_field_values, ...poData } = args;
-      const lineItemsWithCfv = line_items.map((item) => {
-        const { custom_field_values: itemCfv, ...itemData } = item;
-        return {
-          ...itemData,
-          ...(itemCfv ? { custom_field_values_attributes: itemCfv } : {}),
-        };
-      });
+      const { commit, line_items, approver_list, iso_code, on_behalf_of, custom_field_values_attributes, ...poData } = args;
       const body: Record<string, unknown> = {
         commit,
         purchase_order: {
           ...poData,
-          purchase_order_items_attributes: lineItemsWithCfv,
+          ...(iso_code ? { iso_code } : {}),
+          ...(on_behalf_of ? { on_behalf_of } : {}),
+          purchase_order_items_attributes: line_items,
           ...(approver_list ? { approver_list } : {}),
-          ...(custom_field_values ? { custom_field_values_attributes: custom_field_values } : {}),
+          ...(custom_field_values_attributes ? { custom_field_values_attributes } : {}),
         },
       };
       const po = await apiClient.post<PurchaseOrder>(apiClient.buildPath("/purchase_orders"), body);
+      return jsonResponse(po);
+    }),
+  );
+
+  server.registerTool(
+    "update_purchase_order",
+    {
+      description:
+        "Update an existing purchase order. Use commit='Send' to submit a draft for approval. The ID accepts numeric ID, approval-key, or slug.",
+      inputSchema: {
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
+        commit: z.enum(["Send", "Draft"]).optional().describe("'Send' to submit draft for approval"),
+        department_id: z.number().int().optional().describe("Department ID"),
+        supplier_id: z.number().int().optional().describe("Supplier ID"),
+        supplier_name: z.string().optional().describe("Supplier name"),
+        new_supplier_name: z.string().optional().describe("Create a new supplier with this name"),
+        currency_id: z.number().int().optional().describe("Currency ID"),
+        notes: z.string().optional().describe("PO notes"),
+        submitted_on: z.string().optional().describe("Submission date"),
+        line_items: z.array(lineItemSchema).optional().describe("Line items (include id to update existing, _destroy to remove)"),
+        approver_list: z.array(z.number().int()).optional().describe("Approver user IDs"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const { id, commit, line_items, approver_list, ...poData } = args;
+      const body: Record<string, unknown> = {
+        ...(commit ? { commit } : {}),
+        purchase_order: {
+          ...poData,
+          ...(line_items ? { purchase_order_items_attributes: line_items } : {}),
+          ...(approver_list ? { approver_list } : {}),
+        },
+      };
+      const po = await apiClient.put<PurchaseOrder>(apiClient.buildPath(`/purchase_orders/${id}`), body);
       return jsonResponse(po);
     }),
   );
@@ -110,7 +194,7 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
     {
       description: "Approve a purchase order using the accept token from the approver request",
       inputSchema: {
-        id: z.number().int().positive().describe("Purchase Order ID"),
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
         token: z.string().describe("Accept token from the approver request"),
       },
     },
@@ -125,7 +209,7 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
     {
       description: "Reject a purchase order using the reject token from the approver request",
       inputSchema: {
-        id: z.number().int().positive().describe("Purchase Order ID"),
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
         token: z.string().describe("Reject token from the approver request"),
       },
     },
@@ -138,9 +222,9 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "override_and_approve_purchase_order",
     {
-      description: "Override and approve a purchase order (finance users only, no token required)",
+      description: "Override and approve a purchase order (finance role required, no token needed)",
       inputSchema: {
-        id: z.number().int().positive().describe("Purchase Order ID"),
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
       },
     },
     withErrorHandling(async (args) => {
@@ -152,9 +236,9 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "cancel_purchase_order",
     {
-      description: "Cancel a purchase order",
+      description: "Cancel a purchase order (requires cancel permission)",
       inputSchema: {
-        id: z.number().int().positive().describe("Purchase Order ID"),
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
       },
     },
     withErrorHandling(async (args) => {
@@ -166,9 +250,9 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "archive_purchase_order",
     {
-      description: "Archive a purchase order",
+      description: "Toggle archive status of a purchase order (finance role required). Calling again will dearchive.",
       inputSchema: {
-        id: z.number().int().positive().describe("Purchase Order ID"),
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
       },
     },
     withErrorHandling(async (args) => {
@@ -178,9 +262,39 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
   );
 
   server.registerTool(
+    "delete_purchase_order",
+    {
+      description: "Permanently delete a purchase order (requires destroy permission)",
+      inputSchema: {
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.delete(apiClient.buildPath(`/purchase_orders/${args.id}/delete`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "generate_purchase_order_pdf",
+    {
+      description: "Generate a PDF for a purchase order and return a download link",
+      inputSchema: {
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.get<{ pdf_link: string }>(
+        apiClient.buildPath(`/purchase_orders/${args.id}/generate_pdf`),
+      );
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
     "get_pending_request_count",
     {
-      description: "Get the count of pending approval requests",
+      description: "Get the count of pending approval requests for the current user",
       inputSchema: {},
     },
     withErrorHandling(async () => {
@@ -194,18 +308,18 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "receive_purchase_order_items",
     {
-      description: "Mark items as received for a purchase order",
+      description: "Mark line items as received (partial or full delivery) for a purchase order",
       inputSchema: {
-        id: z.number().int().positive().describe("Purchase Order ID"),
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
         items: z
           .array(
             z.object({
-              id: z.number().int().describe("PO item ID"),
+              id: z.number().int().describe("PO line item ID"),
               quantity: z.number().describe("Quantity received"),
             }),
           )
           .describe("Items with received quantities"),
-        delivered_on: z.string().describe("Delivery date"),
+        delivered_on: z.string().describe("Delivery date (format depends on company date_format)"),
         notes: z.string().optional().describe("Delivery notes"),
       },
     },
@@ -217,6 +331,34 @@ export function registerPurchaseOrderTools(server: Server, apiClient: ApiClient)
           notes: args.notes,
         },
       });
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "cancel_receiving_items",
+    {
+      description: "Cancel all received deliveries for a purchase order, reverting to not delivered status",
+      inputSchema: {
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.post(apiClient.buildPath(`/purchase_orders/${args.id}/cancel_receiving_items`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "complete_purchase_order_delivery",
+    {
+      description: "Mark a purchase order as fully delivered",
+      inputSchema: {
+        id: z.string().describe("Purchase Order ID, approval-key, or slug"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.post(apiClient.buildPath(`/purchase_orders/${args.id}/complete_delivery`));
       return jsonResponse(result);
     }),
   );

--- a/src/tools/supplementary.ts
+++ b/src/tools/supplementary.ts
@@ -14,14 +14,18 @@ export function registerSupplementaryTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "list_chart_of_accounts",
     {
-      description: "List chart of accounts with optional search",
+      description: "List chart of accounts (GL codes) with pagination and optional search",
       inputSchema: {
-        search: z.string().optional().describe("Search term"),
+        search: z.string().optional().describe("Search by account name or code"),
+        page: z.number().int().positive().optional().describe("Page number (default: 1)"),
+        per_page: z.number().int().positive().optional().describe("Results per page (default: company setting)"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
       if (args.search) params.set("search", args.search);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
       const query = params.toString();
       const path = `${apiClient.buildPath("/chart_of_accounts")}${query ? `?${query}` : ""}`;
       const result = await apiClient.get<{
@@ -33,16 +37,34 @@ export function registerSupplementaryTools(server: Server, apiClient: ApiClient)
   );
 
   server.registerTool(
+    "get_chart_of_account",
+    {
+      description: "Get a specific chart of account by ID",
+      inputSchema: {
+        id: z.number().int().positive().describe("Chart of Account ID"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.get<ChartOfAccount>(apiClient.buildPath(`/chart_of_accounts/${args.id}`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
     "list_qbo_customers",
     {
-      description: "List QuickBooks customers with optional search",
+      description: "List QuickBooks customers with pagination and optional search",
       inputSchema: {
-        search: z.string().optional().describe("Search term"),
+        search: z.string().optional().describe("Search by customer name"),
+        page: z.number().int().positive().optional().describe("Page number (default: 1)"),
+        per_page: z.number().int().positive().optional().describe("Results per page"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
       if (args.search) params.set("search", args.search);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
       const query = params.toString();
       const path = `${apiClient.buildPath("/qbo_customers")}${query ? `?${query}` : ""}`;
       const result = await apiClient.get<{
@@ -54,22 +76,54 @@ export function registerSupplementaryTools(server: Server, apiClient: ApiClient)
   );
 
   server.registerTool(
+    "get_qbo_customer",
+    {
+      description: "Get a specific QuickBooks customer by ID",
+      inputSchema: {
+        id: z.number().int().positive().describe("QBO Customer ID"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.get<QboCustomer>(apiClient.buildPath(`/qbo_customers/${args.id}`));
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
     "list_qbo_classes",
     {
-      description: "List QuickBooks classes with optional search",
+      description: "List QuickBooks classes with pagination and optional search",
       inputSchema: {
-        search: z.string().optional().describe("Search term"),
+        search: z.string().optional().describe("Search by class name"),
+        page: z.number().int().positive().optional().describe("Page number (default: 1)"),
+        per_page: z.number().int().positive().optional().describe("Results per page"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
       if (args.search) params.set("search", args.search);
+      if (args.page) params.set("page", String(args.page));
+      if (args.per_page) params.set("per_page", String(args.per_page));
       const query = params.toString();
       const path = `${apiClient.buildPath("/qbo_classes")}${query ? `?${query}` : ""}`;
       const result = await apiClient.get<{
         quickbooks_classes: QboClass[];
         meta: PaginationMeta;
       }>(path);
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "get_qbo_class",
+    {
+      description: "Get a specific QuickBooks class by ID",
+      inputSchema: {
+        id: z.number().int().positive().describe("QuickBooks Class ID"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.get<QboClass>(apiClient.buildPath(`/qbo_classes/${args.id}`));
       return jsonResponse(result);
     }),
   );
@@ -91,16 +145,15 @@ export function registerSupplementaryTools(server: Server, apiClient: ApiClient)
   server.registerTool(
     "forward_purchase_order",
     {
-      description: "Forward a purchase order to supplier(s) via email",
+      description:
+        "Forward a purchase order to supplier(s) via email. The PO PDF is attached automatically.",
       inputSchema: {
         purchase_order_id: z.number().int().positive().describe("Purchase Order ID"),
-        emails: z.array(z.string().email()).describe("Recipient email addresses"),
-        cc: z.string().email().optional().describe("CC email address"),
-        notes: z.string().optional().describe("Email body / template text"),
-        email_subject: z.string().optional().describe("Email subject"),
-        template_label: z.string().optional().describe("Template label"),
-        save_template: z.boolean().optional().describe("Save as new template"),
-        is_default: z.boolean().optional().describe("Mark as default template"),
+        emails: z.string().describe("Comma-separated recipient email addresses"),
+        cc: z.string().optional().describe("CC email address (defaults to PO creator's email)"),
+        note: z.string().optional().describe("Email body / note text"),
+        email_subject: z.string().optional().describe("Email subject line"),
+        uploads: z.array(z.number().int()).optional().describe("Upload IDs to attach (must belong to this PO)"),
       },
     },
     withErrorHandling(async (args) => {

--- a/src/tools/suppliers.ts
+++ b/src/tools/suppliers.ts
@@ -8,25 +8,46 @@ export function registerSupplierTools(server: Server, apiClient: ApiClient): voi
   server.registerTool(
     "list_suppliers",
     {
-      description: "List suppliers with pagination and filters",
+      description:
+        "List suppliers. When page param is provided, returns paginated response with meta (20 per page). Without page param, returns all suppliers as an array. Supports search by name and filtering by department/archived status.",
       inputSchema: {
-        page: z.number().int().positive().optional().describe("Page number"),
-        department_id: z.number().int().optional().describe("Filter by department ID"),
-        archived: z.boolean().optional().describe("Filter by archived status"),
-        top: z.number().int().positive().optional().describe("Limit to top N suppliers"),
+        page: z.number().int().positive().optional().describe("Page number — enables pagination (20 per page)"),
+        search: z.string().optional().describe("Search suppliers by name"),
+        department_id: z.number().int().optional().describe("Filter by department ID (includes suppliers without departments)"),
+        archived: z.boolean().optional().describe("Filter by archived status (default: false)"),
+        show_mappings: z.boolean().optional().describe("Include third-party ID mappings in response"),
       },
     },
     withErrorHandling(async (args) => {
       const params = new URLSearchParams();
       if (args.page) params.set("page", String(args.page));
+      if (args.search) params.set("search", args.search);
       if (args.department_id) params.set("department_id", String(args.department_id));
       if (args.archived !== undefined) params.set("archived", String(args.archived));
-      if (args.top) params.set("top", String(args.top));
+      if (args.show_mappings) params.set("show_mappings", "true");
       const query = params.toString();
-      const path = args.top
-        ? `${apiClient.buildPath("/suppliers/top")}?${query}`
-        : `${apiClient.buildPath("/suppliers")}${query ? `?${query}` : ""}`;
-      const result = await apiClient.get<{ suppliers: Supplier[]; meta: PaginationMeta }>(path);
+      const path = `${apiClient.buildPath("/suppliers")}${query ? `?${query}` : ""}`;
+      const result = await apiClient.get<Supplier[] | { suppliers: Supplier[]; meta: PaginationMeta }>(path);
+      return jsonResponse(result);
+    }),
+  );
+
+  server.registerTool(
+    "get_top_suppliers",
+    {
+      description: "Get the user's most frequently used suppliers",
+      inputSchema: {
+        top: z.number().int().positive().optional().describe("Number of top suppliers to return (default: 5)"),
+        archived: z.boolean().optional().describe("Include archived suppliers"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const params = new URLSearchParams();
+      if (args.top) params.set("top", String(args.top));
+      if (args.archived !== undefined) params.set("archived", String(args.archived));
+      const query = params.toString();
+      const path = `${apiClient.buildPath("/suppliers/top")}${query ? `?${query}` : ""}`;
+      const result = await apiClient.get<Supplier[]>(path);
       return jsonResponse(result);
     }),
   );
@@ -48,24 +69,24 @@ export function registerSupplierTools(server: Server, apiClient: ApiClient): voi
   server.registerTool(
     "create_supplier",
     {
-      description: "Create a new supplier (name must be unique)",
+      description:
+        "Create a new supplier (name must be unique within the company). If company has supplier approval enabled, creates a pending approval request instead.",
       inputSchema: {
         name: z.string().describe("Supplier name (must be unique)"),
-        email: z.string().email().optional().describe("Supplier email"),
+        email: z.string().optional().describe("Supplier email"),
         address: z.string().optional().describe("Address"),
         notes: z.string().optional().describe("Notes"),
-        payment_details: z.string().optional().describe("Payment details"),
+        payment_details: z.string().optional().describe("Payment details/bank info"),
         phone_number: z.string().optional().describe("Phone number"),
         tax_number: z.string().optional().describe("Tax number"),
-        contact_person: z.string().optional().describe("Contact person"),
-        department_ids: z.array(z.number().int()).optional().describe("Department IDs"),
+        contact_person: z.string().optional().describe("Contact person name"),
+        uei: z.string().optional().describe("Unique Entity Identifier (UEI) for SAM.gov"),
+        cage_code: z.string().optional().describe("CAGE code for government contracting"),
+        department_ids: z.array(z.number().int()).optional().describe("Department IDs to restrict supplier to"),
       },
     },
     withErrorHandling(async (args) => {
-      const { department_ids, ...supplierData } = args;
-      const body: Record<string, unknown> = { supplier: supplierData };
-      if (department_ids) body.department_ids = department_ids;
-      const supplier = await apiClient.post<Supplier>(apiClient.buildPath("/suppliers"), body);
+      const supplier = await apiClient.post<Supplier>(apiClient.buildPath("/suppliers"), { supplier: args });
       return jsonResponse(supplier);
     }),
   );
@@ -77,7 +98,7 @@ export function registerSupplierTools(server: Server, apiClient: ApiClient): voi
       inputSchema: {
         id: z.number().int().positive().describe("Supplier ID"),
         name: z.string().optional().describe("Supplier name"),
-        email: z.string().email().optional().describe("Email"),
+        email: z.string().optional().describe("Email"),
         address: z.string().optional().describe("Address"),
         notes: z.string().optional().describe("Notes"),
         payment_details: z.string().optional().describe("Payment details"),
@@ -85,6 +106,9 @@ export function registerSupplierTools(server: Server, apiClient: ApiClient): voi
         archived: z.boolean().optional().describe("Archive status"),
         tax_number: z.string().optional().describe("Tax number"),
         contact_person: z.string().optional().describe("Contact person"),
+        uei: z.string().optional().describe("Unique Entity Identifier (UEI)"),
+        cage_code: z.string().optional().describe("CAGE code"),
+        department_ids: z.array(z.number().int()).optional().describe("Department IDs"),
       },
     },
     withErrorHandling(async (args) => {

--- a/src/tools/tax-rates.ts
+++ b/src/tools/tax-rates.ts
@@ -8,11 +8,17 @@ export function registerTaxRateTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "list_tax_rates",
     {
-      description: "List all tax rates (single and combined types)",
-      inputSchema: {},
+      description: "List tax rates for the current company, filtered by archived status",
+      inputSchema: {
+        archived: z.boolean().optional().describe("Filter by archived status (default: false)"),
+      },
     },
-    withErrorHandling(async () => {
-      const taxRates = await apiClient.get<TaxRate[]>(apiClient.buildPath("/tax_rates"));
+    withErrorHandling(async (args) => {
+      const params = new URLSearchParams();
+      if (args.archived !== undefined) params.set("archived", String(args.archived));
+      const query = params.toString();
+      const path = `${apiClient.buildPath("/tax_rates")}${query ? `?${query}` : ""}`;
+      const taxRates = await apiClient.get<TaxRate[]>(path);
       return jsonResponse(taxRates);
     }),
   );
@@ -34,11 +40,10 @@ export function registerTaxRateTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "create_tax_rate",
     {
-      description: "Create a new tax rate",
+      description: "Create a new tax rate for the current company",
       inputSchema: {
-        name: z.string().describe("Tax rate name"),
-        value: z.number().describe("Tax rate value (percentage)"),
-        company_id: z.number().int().describe("Company ID"),
+        name: z.string().describe("Tax rate name (e.g. 'VAT 20%')"),
+        value: z.number().describe("Tax rate percentage value (e.g. 20 for 20%)"),
       },
     },
     withErrorHandling(async (args) => {
@@ -54,7 +59,7 @@ export function registerTaxRateTools(server: Server, apiClient: ApiClient): void
       inputSchema: {
         id: z.number().int().positive().describe("Tax Rate ID"),
         name: z.string().optional().describe("Tax rate name"),
-        value: z.number().optional().describe("Tax rate value"),
+        value: z.number().optional().describe("Tax rate percentage value"),
         archived: z.boolean().optional().describe("Archive status"),
       },
     },

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -20,12 +20,15 @@ export function registerUserTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "update_current_user",
     {
-      description: "Update the current user's profile (email, name, phone number, password)",
+      description: "Update the current user's profile. Include password_confirmation when changing password.",
       inputSchema: {
         email: z.string().email().optional().describe("New email address"),
-        name: z.string().optional().describe("New name"),
-        phone_number: z.string().optional().describe("New phone number"),
+        name: z.string().optional().describe("Full name"),
+        first_name: z.string().optional().describe("First name"),
+        last_name: z.string().optional().describe("Last name"),
+        phone_number: z.string().optional().describe("Phone number"),
         password: z.string().optional().describe("New password"),
+        password_confirmation: z.string().optional().describe("Password confirmation (required when changing password)"),
       },
     },
     withErrorHandling(async (args) => {
@@ -37,7 +40,7 @@ export function registerUserTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_currencies",
     {
-      description: "List enabled currencies for the current company",
+      description: "List currencies enabled for the current company (company default currency listed first)",
       inputSchema: {},
     },
     withErrorHandling(async () => {
@@ -49,7 +52,7 @@ export function registerUserTools(server: Server, apiClient: ApiClient): void {
   server.registerTool(
     "list_all_currencies",
     {
-      description: "List all available currencies globally",
+      description: "List all available currencies globally, sorted by name (or by most popular if company ID is set)",
       inputSchema: {},
     },
     withErrorHandling(async () => {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -8,9 +8,9 @@ export function registerWebhookTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "list_webhooks",
     {
-      description: "List webhooks with optional archived filter",
+      description: "List webhooks for the current company, ordered by creation date",
       inputSchema: {
-        archived: z.boolean().optional().describe("Filter by archived status"),
+        archived: z.boolean().optional().describe("Filter by archived status (default: false)"),
       },
     },
     withErrorHandling(async (args) => {
@@ -26,7 +26,7 @@ export function registerWebhookTools(server: Server, apiClient: ApiClient): void
   server.registerTool(
     "get_webhook",
     {
-      description: "Get a specific webhook by ID",
+      description: "Get a specific webhook by ID including its custom attributes",
       inputSchema: {
         id: z.number().int().positive().describe("Webhook ID"),
       },
@@ -44,18 +44,38 @@ export function registerWebhookTools(server: Server, apiClient: ApiClient): void
         "Create a webhook. Events: new_po, po_approved, po_delivered, po_paid, po_cancelled, po_update",
       inputSchema: {
         name: z.string().describe("Webhook name"),
-        url: z.string().url().describe("Handler URL"),
+        url: z.string().describe("Handler URL"),
         event_type: z
           .array(z.enum(["new_po", "po_approved", "po_delivered", "po_paid", "po_cancelled", "po_update"]))
           .describe("Events to subscribe to"),
-        json_wrapper: z.string().optional().describe("Root key for JSON data"),
+        authentication_header: z.string().optional().describe("Custom authentication header value"),
+        json_wrapper: z.string().optional().describe("Root key for JSON payload wrapping"),
         send_as_text: z.boolean().optional().describe("Send payload as text instead of JSON"),
         basic_auth_uname: z.string().optional().describe("Basic auth username"),
         basic_auth_pword: z.string().optional().describe("Basic auth password"),
+        webhook_attributes: z
+          .array(
+            z.object({
+              attrib_type: z.string().describe("Attribute type"),
+              key: z.string().describe("Attribute key"),
+              value: z.string().describe("Attribute value"),
+            }),
+          )
+          .optional()
+          .describe("Custom webhook attributes (key-value pairs sent with each webhook)"),
       },
     },
     withErrorHandling(async (args) => {
-      const webhook = await apiClient.post<Webhook>(apiClient.buildPath("/webhooks"), { webhook: args });
+      const { webhook_attributes, ...webhookData } = args;
+      const body: Record<string, unknown> = {
+        webhook: {
+          ...webhookData,
+          ...(webhook_attributes
+            ? { webhook_attributes_attributes: webhook_attributes }
+            : {}),
+        },
+      };
+      const webhook = await apiClient.post<Webhook>(apiClient.buildPath("/webhooks"), body);
       return jsonResponse(webhook);
     }),
   );
@@ -67,18 +87,57 @@ export function registerWebhookTools(server: Server, apiClient: ApiClient): void
       inputSchema: {
         id: z.number().int().positive().describe("Webhook ID"),
         name: z.string().optional().describe("Webhook name"),
-        url: z.string().url().optional().describe("Handler URL"),
+        url: z.string().optional().describe("Handler URL"),
         event_type: z
           .array(z.enum(["new_po", "po_approved", "po_delivered", "po_paid", "po_cancelled", "po_update"]))
           .optional()
           .describe("Events to subscribe to"),
+        authentication_header: z.string().optional().describe("Custom authentication header value"),
+        json_wrapper: z.string().optional().describe("Root key for JSON payload wrapping"),
+        send_as_text: z.boolean().optional().describe("Send payload as text instead of JSON"),
+        basic_auth_uname: z.string().optional().describe("Basic auth username"),
+        basic_auth_pword: z.string().optional().describe("Basic auth password"),
         archived: z.boolean().optional().describe("Archive status"),
+        webhook_attributes: z
+          .array(
+            z.object({
+              id: z.number().int().optional().describe("Attribute ID (for updates)"),
+              attrib_type: z.string().optional().describe("Attribute type"),
+              key: z.string().optional().describe("Attribute key"),
+              value: z.string().optional().describe("Attribute value"),
+              _destroy: z.boolean().optional().describe("Set true to remove"),
+            }),
+          )
+          .optional()
+          .describe("Custom webhook attributes"),
       },
     },
     withErrorHandling(async (args) => {
-      const { id, ...data } = args;
-      const webhook = await apiClient.put<Webhook>(apiClient.buildPath(`/webhooks/${id}`), { webhook: data });
+      const { id, webhook_attributes, ...data } = args;
+      const body: Record<string, unknown> = {
+        webhook: {
+          ...data,
+          ...(webhook_attributes
+            ? { webhook_attributes_attributes: webhook_attributes }
+            : {}),
+        },
+      };
+      const webhook = await apiClient.put<Webhook>(apiClient.buildPath(`/webhooks/${id}`), body);
       return jsonResponse(webhook);
+    }),
+  );
+
+  server.registerTool(
+    "delete_webhook",
+    {
+      description: "Delete a webhook",
+      inputSchema: {
+        id: z.number().int().positive().describe("Webhook ID"),
+      },
+    },
+    withErrorHandling(async (args) => {
+      const result = await apiClient.delete(apiClient.buildPath(`/webhooks/${args.id}`));
+      return jsonResponse(result);
     }),
   );
 }

--- a/tests/e2e/budgets.test.ts
+++ b/tests/e2e/budgets.test.ts
@@ -21,10 +21,9 @@ describe("Budgets E2E", () => {
   });
 
   it("should list budgets", async () => {
-    const result = await apiClient.get<any>(apiClient.buildPath("/budgets"));
-    expect(result.budgets).toHaveLength(2);
-    expect(result.meta.total_count).toBe(2);
-    expect(result.budgets[0].name).toBe("Q1 Budget");
+    const result = await apiClient.get<any[]>(apiClient.buildPath("/budgets"));
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Q1 Budget");
   });
 
   it("should get a specific budget", async () => {

--- a/tests/e2e/comments.test.ts
+++ b/tests/e2e/comments.test.ts
@@ -21,7 +21,7 @@ describe("Comments E2E", () => {
   });
 
   it("should add a comment to a purchase order", async () => {
-    const result = await apiClient.post<any>(apiClient.buildPath("/purchase_order/1/comments"), {
+    const result = await apiClient.post<any>(apiClient.buildPath("/purchase_orders/1/comments"), {
       comment: "This looks good!",
     });
     expect(result.id).toBe(1);

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -195,13 +195,10 @@ export function registerStandardRoutes(mock: MockApiServer): void {
     path: vPath("budgets"),
     handler: () => ({
       status: 200,
-      body: {
-        budgets: [
-          { id: 1, name: "Q1 Budget", amount: 50000, currency_id: 1, remaining_amount: 30000 },
-          { id: 2, name: "Q2 Budget", amount: 75000, currency_id: 1, remaining_amount: 75000 },
-        ],
-        meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 2 },
-      },
+      body: [
+        { id: 1, name: "Q1 Budget", amount: 50000, currency_id: 1, remaining_amount: 30000 },
+        { id: 2, name: "Q2 Budget", amount: 75000, currency_id: 1, remaining_amount: 75000 },
+      ],
     }),
   });
 
@@ -503,7 +500,7 @@ export function registerStandardRoutes(mock: MockApiServer): void {
   // Comments (V1/V3)
   mock.registerRoute({
     method: "POST",
-    path: /^\/api\/v[13]\/purchase_order\/\d+\/comments$/,
+    path: /^\/api\/v[13]\/purchase_orders\/\d+\/comments$/,
     handler: (_req, body) => {
       const parsed = JSON.parse(body);
       return {


### PR DESCRIPTION
## Summary

- **Align MCP tools with actual Rails API**: Updated all 14 tool files to match current backend controllers — added `custom_field_values_attributes` support (PO/invoice/budget level + line item level), expanded enum filters, added missing approval flow endpoints (versions, entity, rerun), added `delete_webhook`, and fixed parameter types
- **Add 10 module-specific AI skills**: Created `.claude/skills/pex-*` covering all 80+ MCP tools with zero orphans — each skill routes agents to the correct tool calls with exact parameter docs, enum values, response fields, and cross-skill dependency chains
- **Complex skills include reference files**: PO line items + workflows, invoice line items, approval flow conditions — using progressive disclosure to keep SKILL.md lean

### Skills Created

| Skill | Tools | Key Content |
|-------|-------|-------------|
| pex-auth | 5 | V1/V3 auth flows, token management |
| pex-companies | 12 | Company settings, employees, invites, approvers |
| pex-budgets | 4 | Budget CRUD with custom fields |
| pex-departments | 4 | Department management |
| pex-suppliers | 9 | Suppliers + products (catalog items) |
| pex-purchase-orders | 18 | Full PO lifecycle, delivery, PDF, forwarding |
| pex-invoices | 12 | Invoice lifecycle, approval flow |
| pex-payments | 3 | Invoice + PO payment settlement |
| pex-approval-flows | 13 | Flow config, conditions, versions, runs |
| pex-settings | 17 | Tax rates, webhooks, currencies, GL codes, QBO |

## Test plan

- [x] Verify all MCP tools still pass existing E2E tests (`npm test`)
- [ ] Test skill triggering: ask an AI agent about each module and confirm correct skill loads
- [ ] Verify no sensitive data in skills (no tokens, passwords, or internal URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)