### PR TITLE
Release v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@procurementexpress.com/mcp",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@procurementexpress.com/mcp",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procurementexpress.com/mcp",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "MCP server for ProcurementExpress API",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump package version to 3.0.0 for npm publish.

Major version bump reflecting the comprehensive API audit milestone:
- 35+ new MCP tools (custom fields, compliance, uploads, policies, chat, SAM.gov, digital invoices)
- All Zod schemas aligned with Rails strong params
- All TypeScript types matched to Rails serializers
- 211 E2E tests with Zod rejection coverage for all 20 tool groups
- V3-only chat messages properly gated

## Merge Instructions

After merging, run `/npm-publish` to publish to npm.